### PR TITLE
477 download attribute update

### DIFF
--- a/cypress/integration/work_page_spec.js
+++ b/cypress/integration/work_page_spec.js
@@ -324,7 +324,7 @@ describe("Work page", () => {
         cy.contains("HTML Embed").click();
         cy.contains("HTML Tag");
         cy.contains(
-          '<img src="https://iiif.stack.rdc.library.northwestern.edu/iiif/2/c331c48e-0dda-4e4b-a566-b9a5e0129ce3/full/3000,/0/bitonal.jpg" alt="Front cover">'
+          '<img src="https://iiif.stack.rdc.library.northwestern.edu/iiif/2/c331c48e-0dda-4e4b-a566-b9a5e0129ce3/full/3000,/0/default.jpg" alt="Front cover">'
         );
         cy.contains("1800 pixels (500%)").click();
         cy.contains("Gray").click();

--- a/src/components/UI/IIIFImageEmbedModal.js
+++ b/src/components/UI/IIIFImageEmbedModal.js
@@ -78,7 +78,6 @@ export default function IIIFImageEmbedModal({
   iiifServerUrl,
   modalOpen
 }) {
-  //const iiifUrl = "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/";
   const [color, setColor] = useState("default");
   const [width, setWidth] = useState(3000);
   const [embedCode, setEmbedCode] = useState();

--- a/src/components/UI/IIIFImageEmbedModal.js
+++ b/src/components/UI/IIIFImageEmbedModal.js
@@ -75,27 +75,28 @@ export default function IIIFImageEmbedModal({
   altLabel,
   closeModal,
   id,
+  iiifServerUrl,
   modalOpen
 }) {
-  const iiifUrl = "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/";
-  const [color, setColor] = useState("bitonal");
+  //const iiifUrl = "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/";
+  const [color, setColor] = useState("default");
   const [width, setWidth] = useState(3000);
   const [embedCode, setEmbedCode] = useState();
   const [copied, setCopied] = useState();
 
   useEffect(() => {
     function buildTag() {
-      return `<img src="${iiifUrl}${id}/full/${width},/0/${color}.jpg" alt="${altLabel}">`;
+      return `<img src="${iiifServerUrl}/${id}/full/${width},/0/${color}.jpg" alt="${altLabel}">`;
     }
     setEmbedCode(buildTag());
-  }, [id, color, width, altLabel]);
+  }, [id, color, iiifServerUrl, width, altLabel]);
 
   function handleClose() {
     setCopied(false);
 
     // Reset to defaults
     setWidth(3000);
-    setColor("bitonal");
+    setColor("default");
 
     closeModal();
   }
@@ -173,6 +174,18 @@ export default function IIIFImageEmbedModal({
                 <strong>Image color</strong>
               </legend>
               <input
+                id="default"
+                name="color"
+                type="radio"
+                value="default"
+                onChange={handleColorChange}
+                checked={color === "default"}
+              />
+              <label className="inline" htmlFor="default">
+                Default
+              </label>
+
+              <input
                 id="bitonal"
                 name="color"
                 type="radio"
@@ -183,6 +196,7 @@ export default function IIIFImageEmbedModal({
               <label className="inline" htmlFor="bitonal">
                 Bitonal
               </label>
+
               <input
                 id="gray"
                 name="color"
@@ -193,17 +207,6 @@ export default function IIIFImageEmbedModal({
               />
               <label className="inline" htmlFor="gray">
                 Gray
-              </label>
-              <input
-                id="color"
-                name="color"
-                type="radio"
-                value="color"
-                onChange={handleColorChange}
-                checked={color === "color"}
-              />
-              <label className="inline" htmlFor="color">
-                Color
               </label>
             </fieldset>
           </div>
@@ -238,5 +241,6 @@ IIIFImageEmbedModal.propTypes = {
   altLabel: PropTypes.string,
   closeModal: PropTypes.func,
   id: PropTypes.string,
+  iiifServerUrl: PropTypes.string,
   modalOpen: PropTypes.bool
 };

--- a/src/components/Work/Tabs/Download.js
+++ b/src/components/Work/Tabs/Download.js
@@ -4,6 +4,7 @@ import { getTileSources } from "../../../services/iiif-parser";
 import UILoadingSpinner from "../../UI/LoadingSpinner";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import IIIFImageEmbedModal from "../../UI/IIIFImageEmbedModal";
+import DownloadIIIFImage from "./DownloadIIIFImage";
 
 /** @jsx jsx */
 import { css, jsx } from "@emotion/core";
@@ -11,8 +12,14 @@ import { css, jsx } from "@emotion/core";
 const downloadWrapper = css`
   max-height: 600px;
   overflow-y: auto;
-  border-top: 1px solid #efefef;
-  border-bottom: 1px solid #efefef;
+`;
+const table = css`
+  td:nth-of-type(1) {
+    width: 175px;
+  }
+  td:nth-of-type(3) {
+    width: 200px;
+  }
 `;
 
 const WorkTabsDownload = React.memo(function({ item }) {
@@ -59,8 +66,13 @@ const WorkTabsDownload = React.memo(function({ item }) {
   return (
     <div css={downloadWrapper} data-testid="tab-content-download">
       <div className="responsive-table">
-        <table className="table-borders">
+        <table css={table}>
           <tbody>
+            <tr className="stripe">
+              <th>Image preview</th>
+              <th>Label</th>
+              <th>Actions</th>
+            </tr>
             {tileSources.map((row, i) => (
               <tr key={row.id} className={`${i % 2 === 0 ? "stripe" : ""}`}>
                 <td>
@@ -71,17 +83,10 @@ const WorkTabsDownload = React.memo(function({ item }) {
                 </td>
                 <td>{row.label}</td>
                 <td>
-                  <p>
-                    <a
-                      href={`${row.id}/full/3000,/0/default.jpg`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      download
-                    >
-                      <FontAwesomeIcon icon="download" /> Download
-                    </a>
-                  </p>
-
+                  <DownloadIIIFImage
+                    imageUrl={`${row.id}/full/3000,/0/default.jpg`}
+                    label={row.label}
+                  />
                   <p>
                     <button
                       className="button-link"

--- a/src/components/Work/Tabs/Download.js
+++ b/src/components/Work/Tabs/Download.js
@@ -22,6 +22,11 @@ const WorkTabsDownload = React.memo(function({ item }) {
   const [currentId, setCurrentId] = useState();
   const [currentLabel, setCurrentLabel] = useState();
 
+  const iiifServerUrl = item.representative_file_url.slice(
+    0,
+    item.representative_file_url.lastIndexOf("/")
+  );
+
   useEffect(() => {
     fetch(item.iiif_manifest)
       .then(response => response.json())
@@ -71,6 +76,7 @@ const WorkTabsDownload = React.memo(function({ item }) {
                       href={`${row.id}/full/3000,/0/default.jpg`}
                       target="_blank"
                       rel="noopener noreferrer"
+                      download
                     >
                       <FontAwesomeIcon icon="download" /> Download
                     </a>
@@ -94,6 +100,7 @@ const WorkTabsDownload = React.memo(function({ item }) {
         altLabel={currentLabel}
         closeModal={closeModal}
         id={currentId}
+        iiifServerUrl={iiifServerUrl}
         modalOpen={modalOpen}
       />
     </div>

--- a/src/components/Work/Tabs/DownloadIIIFImage.js
+++ b/src/components/Work/Tabs/DownloadIIIFImage.js
@@ -1,0 +1,79 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import ClipLoader from "react-spinners/ClipLoader";
+
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+
+const errorMessage = css`
+  color: #b2292e;
+`;
+
+// https://stackoverflow.com/questions/51076581/download-images-using-html-or-javascript
+const DownloadIIIFImage = ({ imageUrl, label }) => {
+  const [loading, setLoading] = useState();
+  const [error, setError] = useState();
+  //const yo = "http://www.foo.bar";
+
+  function handleClick() {
+    setError(false);
+
+    function toDataURL(url) {
+      return fetch(url)
+        .then(response => {
+          return response.blob();
+        })
+        .then(blob => {
+          return URL.createObjectURL(blob);
+        })
+        .catch(e => {
+          console.log("Error creating blob", e);
+        });
+    }
+
+    async function makeBlob() {
+      const a = document.createElement("a");
+      const response = await toDataURL(imageUrl);
+      console.log("response", response);
+
+      // Handle error
+      if (!response) {
+        setError(true);
+        setLoading(false);
+        return;
+      }
+
+      a.href = response;
+      a.download = label ? label.split(" ").join("_") : "";
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      setLoading(false);
+    }
+
+    setLoading(true);
+    makeBlob();
+  }
+
+  return (
+    <div>
+      <button
+        data-testid="download-button"
+        onClick={handleClick}
+        className="button-link"
+      >
+        {!loading && <FontAwesomeIcon icon="download" />}{" "}
+        {loading && <ClipLoader color={"#4e2a84"} size={16} />} Download
+      </button>
+      {error && <p css={errorMessage}>Error creating file download object</p>}
+    </div>
+  );
+};
+
+DownloadIIIFImage.propTypes = {
+  imageUrl: PropTypes.string,
+  label: PropTypes.string
+};
+
+export default DownloadIIIFImage;

--- a/src/components/Work/Tabs/DownloadIIIFImage.js
+++ b/src/components/Work/Tabs/DownloadIIIFImage.js
@@ -10,50 +10,59 @@ const errorMessage = css`
   color: #b2292e;
 `;
 
+async function makeBlob(imageUrl) {
+  if (!imageUrl) {
+    return Promise.resolve({ error: true, message: "No image URL provided" });
+  }
+
+  const response = fetch(imageUrl)
+    .then(blobResponse => {
+      return blobResponse.blob();
+    })
+    .then(blob => {
+      return URL.createObjectURL(blob);
+    })
+    .catch(e => {
+      return Promise.resolve({
+        error: true,
+        message: "Error creating image from url"
+      });
+    });
+
+  return response;
+}
+
 // https://stackoverflow.com/questions/51076581/download-images-using-html-or-javascript
 const DownloadIIIFImage = ({ imageUrl, label }) => {
   const [loading, setLoading] = useState();
   const [error, setError] = useState();
-  //const yo = "http://www.foo.bar";
 
-  function handleClick() {
-    setError(false);
-
-    function toDataURL(url) {
-      return fetch(url)
-        .then(response => {
-          return response.blob();
-        })
-        .then(blob => {
-          return URL.createObjectURL(blob);
-        })
-        .catch(e => {
-          console.log("Error creating blob", e);
-        });
-    }
-
-    async function makeBlob() {
-      const a = document.createElement("a");
-      const response = await toDataURL(imageUrl);
-      console.log("response", response);
-
-      // Handle error
-      if (!response) {
-        setError(true);
-        setLoading(false);
-        return;
-      }
-
-      a.href = response;
-      a.download = label ? label.split(" ").join("_") : "";
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      setLoading(false);
-    }
-
+  async function handleClick() {
     setLoading(true);
-    makeBlob();
+    setError(null);
+
+    const response = await makeBlob(imageUrl);
+
+    // Handle error
+    if (!response || response.error) {
+      setError(
+        response.error
+          ? response.message
+          : "There was an error creating the image"
+      );
+      setLoading(false);
+      return;
+    }
+
+    // Create a DOM element anchor to hold the Blog image
+    // initiate a click event on it to force the download
+    const a = document.createElement("a");
+    a.href = response;
+    a.download = label ? label.split(" ").join("_") : "";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setLoading(false);
   }
 
   return (
@@ -66,7 +75,7 @@ const DownloadIIIFImage = ({ imageUrl, label }) => {
         {!loading && <FontAwesomeIcon icon="download" />}{" "}
         {loading && <ClipLoader color={"#4e2a84"} size={16} />} Download
       </button>
-      {error && <p css={errorMessage}>Error creating file download object</p>}
+      {error && <p css={errorMessage}>{error}</p>}
     </div>
   );
 };

--- a/src/components/Work/Tabs/DownloadIIIFImage.test.js
+++ b/src/components/Work/Tabs/DownloadIIIFImage.test.js
@@ -3,20 +3,10 @@ import { render, fireEvent } from "@testing-library/react";
 import "./DownloadIIIFImage";
 import DownloadIIIFImage from "./DownloadIIIFImage";
 
-global.fetch = jest.fn(() =>
-  Promise.resolve({
-    json: () => Promise.resolve("ABC")
-  })
-);
-
 describe("DownloadIIIFImage component", () => {
   it("renders without crashing", () => {
     expect(render(<DownloadIIIFImage />));
   });
 
-  it("displays an error message when passed a bad image url", () => {
-    const { getByTestId } = render(<DownloadIIIFImage />);
-    const el = getByTestId("download-button");
-    fireEvent.click(el);
-  });
+  //TODO: Add tests here
 });

--- a/src/components/Work/Tabs/DownloadIIIFImage.test.js
+++ b/src/components/Work/Tabs/DownloadIIIFImage.test.js
@@ -1,0 +1,22 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import "./DownloadIIIFImage";
+import DownloadIIIFImage from "./DownloadIIIFImage";
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    json: () => Promise.resolve("ABC")
+  })
+);
+
+describe("DownloadIIIFImage component", () => {
+  it("renders without crashing", () => {
+    expect(render(<DownloadIIIFImage />));
+  });
+
+  it("displays an error message when passed a bad image url", () => {
+    const { getByTestId } = render(<DownloadIIIFImage />);
+    const el = getByTestId("download-button");
+    fireEvent.click(el);
+  });
+});


### PR DESCRIPTION
Another PR to enhance functionality by forcing an image download.  You can test this out by:

1. Clicking "Download" in the "Download" tab, on any Fileset item row.
2. In the HTML Embed modal, the `color` option has been replaced by `default`.

![image](https://user-images.githubusercontent.com/3020266/84943347-dce24780-b0a9-11ea-85f9-01fad81bfc43.png)
