### PR TITLE
Add canonical meta tag to Images redirected content

### DIFF
--- a/src/screens/LegacyPid.js
+++ b/src/screens/LegacyPid.js
@@ -17,11 +17,12 @@ function ScreensLegacyPid() {
     fn();
   }, [params.pid]);
 
-  return loading ? (
-    <UILoadingSpinner />
-  ) : (
-    <Redirect to={id ? `/items/${id}` : "/"} />
-  );
+  let redirectTo = {
+    pathname: id ? `/items/${id}` : "/",
+    state: { hasCanonical: true }
+  };
+
+  return loading ? <UILoadingSpinner /> : <Redirect to={redirectTo} />;
 }
 
 export default ScreensLegacyPid;

--- a/src/screens/Work/Work.js
+++ b/src/screens/Work/Work.js
@@ -127,6 +127,12 @@ const ScreensWork = () => {
             {JSON.stringify(structuredData)}
           </script>
         )}
+        {location.state && location.state.hasCanonical && (
+          <link
+            rel="canonical"
+            href={`${window.location.origin}${location.pathname}`}
+          />
+        )}
       </Helmet>
       <ErrorBoundary>
         {error && <ErrorSection message={error} />}


### PR DESCRIPTION
@davidschober So I'm not sure I entirely understand how this should work, but the way it's currently set up is that any request which hits the Legacy redirect route in DC, will add the following meta tag to the resulting Work screen (see screenshot below).

![image](https://user-images.githubusercontent.com/3020266/84947381-b8896980-b0af-11ea-9632-c40c5783ab28.png)

This doesn't automatically add the tag to every previous Images work, but only if accessed through the re-direction link.  Let me know if this is off the mark?