### PR TITLE
Add canonical link header to Work screen for all Works (not just lega…

### DIFF
--- a/src/screens/LegacyPid.js
+++ b/src/screens/LegacyPid.js
@@ -18,8 +18,7 @@ function ScreensLegacyPid() {
   }, [params.pid]);
 
   let redirectTo = {
-    pathname: id ? `/items/${id}` : "/",
-    state: { hasCanonical: true }
+    pathname: id ? `/items/${id}` : "/"
   };
 
   return loading ? <UILoadingSpinner /> : <Redirect to={redirectTo} />;

--- a/src/screens/Work/Work.js
+++ b/src/screens/Work/Work.js
@@ -127,12 +127,10 @@ const ScreensWork = () => {
             {JSON.stringify(structuredData)}
           </script>
         )}
-        {location.state && location.state.hasCanonical && (
-          <link
-            rel="canonical"
-            href={`${window.location.origin}${location.pathname}`}
-          />
-        )}
+        <link
+          rel="canonical"
+          href={`https://digitalcollections.library.northwestern.edu${location.pathname}`}
+        />
       </Helmet>
       <ErrorBoundary>
         {error && <ErrorSection message={error} />}


### PR DESCRIPTION
…cy pid redirects)

This adds `<link rel="canonical" href="https://digitalcollections.library.northwestern.edu/[route and work id here]  />` to the Work screen for every item.