### PR TITLE
Bump OSD to latest version that works in Meadow too

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "node-sass-chokidar": "^1.3.5",
     "npm-run-all": "^4.1.2",
     "openseadragon": "^2.4.2",
-    "openseadragon-react-viewer": "^2.0.0",
+    "openseadragon-react-viewer": "^2.1.0",
     "react": "^16.13.0",
     "react-app-polyfill": "^1.0.6",
     "react-collapsible": "^2.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8913,10 +8913,10 @@ opencollective-postinstall@^2.0.2:
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
   integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
 
-openseadragon-react-viewer@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/openseadragon-react-viewer/-/openseadragon-react-viewer-2.0.0.tgz#cd9bfb44e809106a02c1a154d4e90f93ec810a87"
-  integrity sha512-mgKW2odSvr8jMesHhI8I3MmFmfQhvb90qMG4Y7PVjNyjL3rIIIREBqw3YjM04ON0URZTBnuzNb11sbEGWVuSPQ==
+openseadragon-react-viewer@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/openseadragon-react-viewer/-/openseadragon-react-viewer-2.1.0.tgz#3754bad01294a7389d44a09732bf03acac5ae5fb"
+  integrity sha512-BKgi//KHZzQ8DCfhC9DiF6wQBEDLJpMgboA6XyLt5yOdZ/GiPBmC+PCDz/LBX6kERRxbRznyH1zUr+yRhjJDvw==
   dependencies:
     "@reglendo/canvas2image" "^1.0.5-2"
     react-device-detect "^1.12.1"


### PR DESCRIPTION
Updates to latest version which fixes a babel config bug observed when Meadow consumed the new player.  It should be stable now.