### PR TITLE
Swiper implementation to home page collections and works

### DIFF
--- a/cypress/integration/home_page_spec.js
+++ b/cypress/integration/home_page_spec.js
@@ -49,12 +49,4 @@ describe("Home page", () => {
         .and("have.class", "back-text");
     });
   });
-
-  it("displays in-page hero section with an image, title, subtitle and link to the collection", () => {
-    cy.get("[data-testid=hero-in-page]").within($hero => {
-      cy.get("[data-testid=hero-in-page-title]");
-      cy.get("[data-testid=hero-in-page-subtitle]");
-      cy.get("[data-testid=hero-in-page-link]").should("have.length.gte", 1);
-    });
-  });
 });

--- a/cypress/integration/home_page_spec.js
+++ b/cypress/integration/home_page_spec.js
@@ -18,7 +18,7 @@ describe("Home page", () => {
     cy.get("[data-testid=section-recent-items]").within($section => {
       cy.get("[data-testid=headline-photo-grid-section]");
       //cy.get("[data-testid=link-photo-grid-section]");
-      cy.contains("View All Items");
+      cy.contains("View All Works");
       cy.get("[data-testid=photo-box]")
         .should("have.length", 8)
         .and("have.class", "photo-box");

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -9,7 +9,7 @@ import * as elasticsearchApi from "../../api/elasticsearch-api";
 import * as elasticsearchParser from "../../services/elasticsearch-parser";
 import * as globalVars from "../../services/global-vars";
 import { getRandomInt } from "../../services/helpers";
-import { isMobile } from "react-device-detect";
+import { isMobileOnly, isTablet } from "react-device-detect";
 // Import Swiper React components
 import SwiperCore, { Navigation } from "swiper";
 import { Swiper, SwiperSlide } from "swiper/react";
@@ -64,7 +64,11 @@ const Home = () => {
           <div className="section-top contain-1440">
             <p className="subhead"> {keyword} Collections</p>
           </div>
-          <Swiper spaceBetween={0} slidesPerView={isMobile ? 1 : 3} navigation>
+          <Swiper
+            spaceBetween={isMobileOnly ? 0 : isTablet ? 10 : 0}
+            slidesPerView={isMobileOnly ? 1 : isTablet ? 2 : 3}
+            navigation
+          >
             {keywordCollections[i].map(item => (
               <SwiperSlide key={item.id}>
                 <div
@@ -140,7 +144,11 @@ const Home = () => {
               </Link>
             </p>
           </div>
-          <Swiper spaceBetween={0} slidesPerView={isMobile ? 1 : 3} navigation>
+          <Swiper
+            spaceBetween={isMobileOnly ? 0 : isTablet ? 10 : 0}
+            slidesPerView={isMobileOnly ? 1 : isTablet ? 2 : 3}
+            navigation
+          >
             {galleryCollections.map(item => (
               <SwiperSlide key={item.id}>
                 <div
@@ -167,13 +175,13 @@ const Home = () => {
         </div>
         <Swiper
           spaceBetween={30}
-          slidesPerView={isMobile ? 2 : 4}
+          slidesPerView={isMobileOnly ? 1 : isTablet ? 2 : 4}
           navigation
           className="photobox-swiper"
         >
           {galleryItems.map(item => (
             <SwiperSlide key={item.id}>
-              <div>
+              <div align="center">
                 <PhotoBox hideDescriptions={true} item={item} />
               </div>
             </SwiperSlide>

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -1,33 +1,23 @@
 import React, { useState, useEffect } from "react";
 import HeroSection from "../../components/Home/HeroSection";
-import HeroSecondarySection from "../../components/Home/HeroSecondarySection";
-import PhotoGridSection from "../UI/PhotoGridSection";
-import PhotoFeatureSection from "../UI/PhotoFeatureSection";
+import PhotoBox from "../UI/PhotoBox";
 import PhotoFeature from "../UI/PhotoFeature";
 import { Link } from "react-router-dom";
 import LoadingSpinner from "../UI/LoadingSpinner";
-import {
-  heroFava,
-  heroWPA,
-  heroWWII,
-  heroWWII_2,
-  heroSecondaryData
-} from "./hero-banners";
+import { heroFava, heroWPA, heroWWII, heroWWII_2 } from "./hero-banners";
 import * as elasticsearchApi from "../../api/elasticsearch-api";
 import * as elasticsearchParser from "../../services/elasticsearch-parser";
 import * as globalVars from "../../services/global-vars";
 import { getRandomInt } from "../../services/helpers";
 import { isMobile } from "react-device-detect";
 // Import Swiper React components
-import SwiperCore, { Navigation, Pagination, Scrollbar } from "swiper";
+import SwiperCore, { Navigation } from "swiper";
 import { Swiper, SwiperSlide } from "swiper/react";
 
 // Import Swiper styles
 import "swiper/swiper.scss";
-import "swiper/components/pagination/pagination.scss";
-import "swiper/components/scrollbar/scrollbar.scss";
 
-SwiperCore.use([Navigation, Pagination, Scrollbar]);
+SwiperCore.use([Navigation]);
 const Home = () => {
   const numResults = 8;
   const heroRandomNumber = getRandomInt(0, 2);
@@ -52,7 +42,7 @@ const Home = () => {
     Promise.all(promises)
       .then(([galleryItems, galleryCollections, ...keywordCollections]) => {
         setGalleryItems(galleryItems);
-        setGalleryCollections(galleryCollections.concat(keywordCollections[2]));
+        setGalleryCollections(galleryCollections);
         setKeywordCollections(keywordCollections);
         setLoading(false);
       })
@@ -70,11 +60,25 @@ const Home = () => {
       }
 
       return (
-        <PhotoFeatureSection
-          key={keyword}
-          headline={`${keyword} Collections`}
-          items={keywordCollections[i]}
-        />
+        <section className="section" key={keyword}>
+          <div className="section-top no-bottom-margin contain-1440">
+            <h3 data-testid="headline-photo-feature-section ">
+              {keyword} Collections
+            </h3>
+          </div>
+          <Swiper spaceBetween={0} slidesPerView={isMobile ? 1 : 3} navigation>
+            {keywordCollections[i].map(item => (
+              <SwiperSlide key={item.id}>
+                <div
+                  className="photo-feature-3-across"
+                  style={{ marginTop: 0 }}
+                >
+                  <PhotoFeature item={item} styles={{ width: "100%" }} />
+                </div>
+              </SwiperSlide>
+            ))}
+          </Swiper>
+        </section>
       );
     });
   }
@@ -128,63 +132,57 @@ const Home = () => {
       <LoadingSpinner loading={loading} />
 
       {!loading && (
-        <>
-          <div>
-            <PhotoFeatureSection
-              subhead="Featured Collections"
-              headline="Collections"
-              linkTo="/collections"
-              linkToText="View All Collections"
-              items={galleryCollections}
-              data-testid="section-featured-collections"
-            />
+        <section className="section" data-testid="section-featured-collections">
+          <div className="section-top contain-1440">
+            <h3 data-testid="headline-photo-feature-section">Collections</h3>
+            <p className="subhead">Featured Collections</p>
+            <p>
+              <Link data-testid="link-photo-feature-section" to="/collections">
+                View All Collections
+              </Link>
+            </p>
           </div>
-          <section className="section">
-            <div className="section-top contain-1440">
-              <h3 data-testid="headline-photo-feature-section">Collections</h3>
-              <p className="subhead">Featured Collections</p>
-              <p>
-                <Link
-                  data-testid="link-photo-feature-section"
-                  to="/collections"
+          <Swiper spaceBetween={0} slidesPerView={isMobile ? 1 : 3} navigation>
+            {galleryCollections.map(item => (
+              <SwiperSlide key={item.id}>
+                <div
+                  className="photo-feature-3-across"
+                  style={{ marginTop: 0 }}
                 >
-                  View All Collections
-                </Link>
-              </p>
-            </div>
-            <Swiper
-              spaceBetween={0}
-              slidesPerView={isMobile ? 1 : 3}
-              onSlideChange={() => console.log("slide change")}
-              onSwiper={swiper => console.log(swiper)}
-              navigation
-            >
-              {galleryCollections.map((item, index) => (
-                <SwiperSlide key={index}>
-                  <div
-                    className="photo-feature-3-across"
-                    style={{ marginTop: 0 }}
-                  >
-                    <PhotoFeature item={item} styles={{ width: "100%" }} />
-                  </div>
-                </SwiperSlide>
-              ))}
-            </Swiper>
-          </section>
-        </>
+                  <PhotoFeature item={item} styles={{ width: "100%" }} />
+                </div>
+              </SwiperSlide>
+            ))}
+          </Swiper>
+        </section>
       )}
-      <div className="contain-1120">
-        <HeroSecondarySection heroData={heroSecondaryData} />
-      </div>
       {!loading && renderAdditionalGalleries()}
-      <PhotoGridSection
-        headline="Recently Added and Updated Items"
-        linkTo="/search"
-        linkToText="View All Items"
-        items={galleryItems}
-        hideDescriptions={true}
-        data-testid="section-recent-items"
-      />
+      <section className="section" data-testid="section-recent-items">
+        <div className="section-top contain-970">
+          <h3 data-testid="headline-photo-grid-section">
+            Recently Added and Updated Items
+          </h3>
+          <p>
+            <Link data-testid="link-photo-grid-section" to="/search">
+              View All Items
+            </Link>
+          </p>
+        </div>
+        <Swiper
+          spaceBetween={30}
+          slidesPerView={isMobile ? 2 : 4}
+          navigation
+          className="photobox-swiper"
+        >
+          {galleryItems.map(item => (
+            <SwiperSlide key={item.id}>
+              <div>
+                <PhotoBox hideDescriptions={true} item={item} />
+              </div>
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      </section>
     </>
   );
 };

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -61,10 +61,8 @@ const Home = () => {
 
       return (
         <section className="section" key={keyword}>
-          <div className="section-top no-bottom-margin contain-1440">
-            <h3 data-testid="headline-photo-feature-section ">
-              {keyword} Collections
-            </h3>
+          <div className="section-top contain-1440">
+            <p className="subhead"> {keyword} Collections</p>
           </div>
           <Swiper spaceBetween={0} slidesPerView={isMobile ? 1 : 3} navigation>
             {keywordCollections[i].map(item => (
@@ -159,12 +157,11 @@ const Home = () => {
       {!loading && renderAdditionalGalleries()}
       <section className="section" data-testid="section-recent-items">
         <div className="section-top contain-970">
-          <h3 data-testid="headline-photo-grid-section">
-            Recently Added and Updated Items
-          </h3>
+          <h3 data-testid="headline-photo-grid-section">Works</h3>
+          <p className="subhead">Recently Added and Updated Works</p>
           <p>
             <Link data-testid="link-photo-grid-section" to="/search">
-              View All Items
+              View All Works
             </Link>
           </p>
         </div>

--- a/src/components/UI/PhotoBox.js
+++ b/src/components/UI/PhotoBox.js
@@ -19,6 +19,9 @@ const PhotoBox = props => {
   }/${props.item.id}`;
 
   let imgSrc = imageUrl ? imageUrl : placeholderImage;
+  const loadPlaceholderImage = e => {
+    e.target.src = placeholderImage;
+  };
 
   return (
     <article
@@ -27,7 +30,12 @@ const PhotoBox = props => {
       data-testid="photo-box"
     >
       <Link to={linkPath}>
-        <img alt={label} src={imgSrc} data-testid="img-photo-box" />
+        <img
+          alt={label}
+          src={imgSrc}
+          data-testid="img-photo-box"
+          onError={loadPlaceholderImage}
+        />
       </Link>
       <h4 data-testid="title-photo-box">
         <Link to={linkPath} style={styles.title}>

--- a/src/components/UI/PhotoFeature.js
+++ b/src/components/UI/PhotoFeature.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import { Link } from "react-router-dom";
+import placeholderImage from "../../images/book_placeholder.png";
 
 import PropTypes from "prop-types";
 /** @jsx jsx */
@@ -42,6 +43,9 @@ const PhotoFeature = props => {
     }
     setIsHover(!isHover);
   };
+  const loadPlaceholderImage = e => {
+    e.target.src = placeholderImage;
+  };
 
   return (
     <article
@@ -61,16 +65,12 @@ const PhotoFeature = props => {
         <div css={!isHover ? frontShow : frontHide}>
           <img
             alt="image description"
-            src={
-              imageUrl
-                ? imageUrl
-                : "https://bulma.io/images/placeholders/480x480.png"
-            }
+            src={imageUrl}
+            onError={loadPlaceholderImage}
             ref={ref}
           />
           <div className="text-over-image" data-testid="front-photo-box">
             <h4>{label}</h4>
-            <p className="link">Learn more</p>
           </div>
         </div>
         <div css={isHover ? backShow : backHide}>

--- a/src/styles/sass/nulib-collections/_nuwebcomm-overrides.scss
+++ b/src/styles/sass/nulib-collections/_nuwebcomm-overrides.scss
@@ -42,15 +42,6 @@
     opacity: 0.5;
   }
 
-  .content {
-    .no-bottom-margin {
-      margin-bottom: 0;
-      h3 {
-        margin-bottom: 2rem;
-      }
-    }
-  }
-
   // For works
   .photobox-swiper {
     .swiper-button-next,

--- a/src/styles/sass/nulib-collections/_nuwebcomm-overrides.scss
+++ b/src/styles/sass/nulib-collections/_nuwebcomm-overrides.scss
@@ -41,6 +41,37 @@
   .swiper-button-disabled {
     opacity: 0.5;
   }
+
+  .content {
+    .no-bottom-margin {
+      margin-bottom: 0;
+      h3 {
+        margin-bottom: 2rem;
+      }
+    }
+  }
+
+  // For works
+  .photobox-swiper {
+    .swiper-button-next,
+    .swiper-button-prev {
+      top: 40%;
+    }
+  }
+  .photo-box {
+    h4 {
+      font: 16px $AkkuratProBold;
+      color: $rich-black-80;
+      margin: 1rem 0 0 0;
+    }
+  }
+  // For overlay contrast
+  .text-over-image {
+    h4 {
+      background-color: rgba($color: #000000, $alpha: 0.5);
+      padding: 0.5rem;
+    }
+  }
 }
 
 @media screen and (max-width: 768px) {

--- a/src/styles/sass/nulib-collections/_nuwebcomm-overrides.scss
+++ b/src/styles/sass/nulib-collections/_nuwebcomm-overrides.scss
@@ -37,6 +37,9 @@
     top: 50%;
     z-index: 10;
   }
+  img {
+    margin: 0 auto;
+  }
 
   .swiper-button-disabled {
     opacity: 0.5;
@@ -55,12 +58,17 @@
       color: $rich-black-80;
       margin: 1rem 0 0 0;
     }
+    img {
+      margin: 0 auto;
+    }
   }
   // For overlay contrast
   .text-over-image {
     h4 {
       background-color: rgba($color: #000000, $alpha: 0.5);
       padding: 0.5rem;
+      max-width: 350px;
+      margin: 0 auto; //center content in the container
     }
   }
 }


### PR DESCRIPTION
- Added placeholder image for broken/non-existing images in collections.
- Swiper CSS unused files removed.
- Added overlay for collection item headers.
- Added swiper to "Recent Works"
- Swiper logic implemented to show "Keyword Collections"

Closes [#910](https://github.com/nulib/repodev_planning_and_docs/issues/910)
Closes [#909](https://github.com/nulib/repodev_planning_and_docs/issues/909)

<img width="1217" alt="Screen Shot 2020-07-14 at 1 51 15 PM" src="https://user-images.githubusercontent.com/14085957/87464652-18a0fc00-c5d9-11ea-9f5f-ece0dd0b3022.png">
