### PR TITLE
Update code to pull in Photography Collection items on homepage

### DIFF
--- a/cypress/integration/home_page_spec.js
+++ b/cypress/integration/home_page_spec.js
@@ -1,4 +1,5 @@
 /// <reference types="cypress" />
+import { HOMEPAGE_COLLECTION_GROUP_KEYWORDS } from "../../src/services/global-vars";
 
 describe("Home page", () => {
   beforeEach(() => {
@@ -48,5 +49,15 @@ describe("Home page", () => {
         .should("contain", "p")
         .and("have.class", "back-text");
     });
+  });
+
+  it("renders additional Collection galleries", () => {
+    cy.getByTestId("section-additional-collection-gallery")
+      .its("length")
+      .should("be.eq", 3);
+
+    for (let keyword of HOMEPAGE_COLLECTION_GROUP_KEYWORDS) {
+      cy.contains(`${keyword} Collections`);
+    }
   });
 });

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -60,7 +60,11 @@ const Home = () => {
       }
 
       return (
-        <section className="section" key={keyword}>
+        <section
+          className="section"
+          key={keyword}
+          data-testid="section-additional-collection-gallery"
+        >
           <div className="section-top contain-1440">
             <p className="subhead"> {keyword} Collections</p>
           </div>

--- a/src/services/global-vars.js
+++ b/src/services/global-vars.js
@@ -40,7 +40,7 @@ export const HONEYBADGER_ENV = process.env.REACT_APP_HONEYBADGER_ENV;
 // This array holds Keyword Metadata values set in Donut, which are used to group Collections
 // on the Homepage
 export const HOMEPAGE_COLLECTION_GROUP_KEYWORDS = [
-  "Posters",
+  "Poster",
   "Photography",
   "Evanston"
 ];


### PR DESCRIPTION
Now pulling in Photography Collections, and added Cypress test to check it's pulling in Collection by keyword defined in the front-end's `/services/global-vars.js` file.

![image](https://user-images.githubusercontent.com/3020266/87718891-2e005c80-c778-11ea-93b8-f4de5cb905e7.png)

@davidschober 