### PR TITLE
Collection description moved under title

### DIFF
--- a/cypress/integration/collections/view_page_spec.js
+++ b/cypress/integration/collections/view_page_spec.js
@@ -34,8 +34,8 @@ describe("Collections View page", () => {
       cy.get("@facetsSidebar").should("not.be.visible");
     });
 
-    it("should display sidebar", () => {
-      cy.get("#sidebar").within($sidebar => {
+    it("should display description", () => {
+      cy.getByTestId("collection-description").within($sidebar => {
         cy.contains("h3", "Collection Description");
         cy.contains("p", "113 antique maps of Africa");
       });

--- a/src/components/Collection/Collection.js
+++ b/src/components/Collection/Collection.js
@@ -28,11 +28,25 @@ import { isMobile } from "react-device-detect";
 import CollectionDescription from "./CollectionDescription";
 import FiltersShowHideButton from "../UI/FiltersShowHideButton";
 
-const styles = {
-  mobileDescription: {
-    marginBottom: "2rem"
+/** @jsx jsx */
+/** @jsxFrag React.Fragment **/
+
+import { css, jsx } from "@emotion/core";
+
+const mobileDescriptionCss = css`
+  margin-bottom: 2rem;
+`;
+const boxDescriptionCss = css`
+  background: #e4e0ee;
+  padding: 1rem;
+  margin-bottom: 2rem;
+  font-size: 14px;
+  line-height: 1.4em;
+  h3 {
+    font: 18px/1.2em "Campton Bold", Impact, sans-serif;
+    color: #342f2e;
   }
-};
+`;
 
 const Collection = () => {
   const [collection, setCollection] = useState();
@@ -190,25 +204,24 @@ const Collection = () => {
             tabIndex="-1"
           >
             <Breadcrumbs items={breadCrumbData} />
+            <h2>{collectionTitle}</h2>
+            {!isMobile && (
+              <div
+                className="box"
+                css={boxDescriptionCss}
+                data-testid="collection-description"
+              >
+                <h3>Collection Description</h3>
+                {descriptionDisplay}
+              </div>
+            )}
+            {isMobile && (
+              <div css={mobileDescriptionCss}>
+                <CollectionDescription description={collectionDescription} />
+              </div>
+            )}
             {!loading && (
               <div>
-                {!isMobile && (
-                  <div id="sidebar">
-                    <div className="box">
-                      <h3>Collection Description</h3>
-                      {descriptionDisplay}
-                    </div>
-                  </div>
-                )}
-
-                <h2>{collectionTitle}</h2>
-
-                {isMobile && (
-                  <div style={styles.mobileDescription}>
-                    <CollectionDescription description={descriptionDisplay} />
-                  </div>
-                )}
-
                 <DataSearch
                   customQuery={simpleQueryStringQuery}
                   autosuggest={false}
@@ -217,7 +230,7 @@ const Collection = () => {
                   dataField={["full_text"]}
                   filterLabel="Collections search"
                   innerClass={{
-                    input: "searchbox rs-search-input",
+                    input: "searchbox rs-search-input is-fullwidth",
                     list: "suggestionlist"
                   }}
                   queryFormat="or"


### PR DESCRIPTION
This PR moved collection description to show under collection title. 
- Sidebar for Description is removed
- Also discovered that Mobile view for expanding description was broken, fixed that.

<img width="1299" alt="Screen Shot 2020-08-25 at 9 47 11 AM" src="https://user-images.githubusercontent.com/14085957/91190015-ba2b6b00-e6b8-11ea-8513-192409ce2ed6.png">
<img width="1395" alt="Screen Shot 2020-08-25 at 9 47 22 AM" src="https://user-images.githubusercontent.com/14085957/91190022-bb5c9800-e6b8-11ea-84c2-9a1607f0eb31.png">
<img width="275" alt="Screen Shot 2020-08-25 at 9 54 58 AM" src="https://user-images.githubusercontent.com/14085957/91190295-0bd3f580-e6b9-11ea-9aa9-2919d35ff15e.png">