### PR TITLE
Remove placeholder text on Work screen when Work has no description

### DIFF
--- a/src/components/Work/LargeFeature.js
+++ b/src/components/Work/LargeFeature.js
@@ -9,8 +9,7 @@ import IIIFDraggable from "./IIIFDraggable";
 const LargeFeature = (props) => {
   const { item } = props;
   const title = elasticSearchParser.getESTitle(item);
-  const description =
-    elasticSearchParser.getESDescription(item) || "No description provided.";
+  const description = elasticSearchParser.getESDescription(item) || "";
 
   const styles = {
     paddedBlock: {


### PR DESCRIPTION
Placeholder text no longer displays.

![image](https://user-images.githubusercontent.com/3020266/102116300-61681580-3e02-11eb-9d8c-3bebd7c8fb83.png)
