### PR TITLE
Restore featured and keyword collections on homepage

### DIFF
--- a/src/api/elasticsearch-api.js
+++ b/src/api/elasticsearch-api.js
@@ -163,8 +163,8 @@ export async function getCollectionsByKeyword(keyword, numResults = PAGE_SIZE) {
         query: {
           bool: {
             must: [
-              { match: { "model.title": "Collection" } },
-              { match: { keyword: keyword } },
+              { match: { "model.name": "Collection" } },
+              { match: { keywords: keyword } },
             ],
           },
         },
@@ -225,7 +225,7 @@ export async function getFeaturedCollections(numResults = PAGE_SIZE) {
         query: {
           bool: {
             must: [
-              { match: { "model.title": "Collection" } },
+              { match: { "model.name": "Collection" } },
               { match: { featured: true } },
             ],
           },

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -35,16 +35,16 @@ const Home = () => {
     // Combine async network requests
     promises.push(getGalleryItems());
     promises.push(getFeaturedCollections());
-    // globalVars.HOMEPAGE_COLLECTION_GROUP_KEYWORDS.forEach(keyword =>
-    //   promises.push(getGalleryByKeyword(keyword))
-    // );
+    globalVars.HOMEPAGE_COLLECTION_GROUP_KEYWORDS.forEach((keyword) =>
+      promises.push(getGalleryByKeyword(keyword))
+    );
 
     // Put results on component state
     Promise.all(promises)
       .then(([galleryItems, featuredCollections, ...keywordCollections]) => {
         setGalleryItems(galleryItems);
         setFeaturedCollections(featuredCollections);
-        //setKeywordCollections(keywordCollections);
+        setKeywordCollections(keywordCollections);
         setLoading(false);
       })
       .catch((error) => console.log("Error grabbing data", error));
@@ -67,7 +67,9 @@ const Home = () => {
           data-testid="section-additional-collection-gallery"
         >
           <div className="section-top contain-1440">
-            <p className="subhead"> {keyword} Collections</p>
+            <p className="subhead" style={{ textTransform: "capitalize" }}>
+              {keyword} Collections
+            </p>
           </div>
           <Swiper
             spaceBetween={isMobileOnly ? 0 : isTablet ? 10 : 0}

--- a/src/services/global-vars.js
+++ b/src/services/global-vars.js
@@ -44,9 +44,9 @@ export const SHARED_ITEM_PROXY_URL =
 // This array holds Keyword Metadata values set in Donut, which are used to group Collections
 // on the Homepage
 export const HOMEPAGE_COLLECTION_GROUP_KEYWORDS = [
-  "Posters",
-  "Photography",
-  "Evanston",
+  "posters",
+  "photography",
+  "evanston",
 ];
 
 // Mobile breakpoint


### PR DESCRIPTION
Fix display of featured and keyword collections on Fen homepage

fixes: https://github.com/nulib/repodev_planning_and_docs/issues/1486
fixes: https://github.com/nulib/repodev_planning_and_docs/issues/1484


<img width="1578" alt="Screen Shot 2021-02-18 at 8 08 37 AM" src="https://user-images.githubusercontent.com/6372022/108379560-4c717f00-71c3-11eb-87f3-ea6464e295d7.png">
<img width="1537" alt="Screen Shot 2021-02-18 at 8 23 23 AM" src="https://user-images.githubusercontent.com/6372022/108379582-509d9c80-71c3-11eb-90ae-db8ef0799d20.png">
