### PR TITLE
Use the (humanized) date created field for date on about tab

### DIFF
--- a/src/components/Work/Tabs/Metadata.js
+++ b/src/components/Work/Tabs/Metadata.js
@@ -16,7 +16,6 @@ const TabsMetadata = ({ item }) => {
   if (!item) return;
   const {
     administrativeMetadata: { libraryUnit }, // = "Library Division"
-    createDate = "",
     descriptiveMetadata,
   } = item;
 
@@ -26,6 +25,7 @@ const TabsMetadata = ({ item }) => {
     caption,
     contributor,
     creator,
+    dateCreated,
     description,
     genre,
     keywords,
@@ -68,7 +68,7 @@ const TabsMetadata = ({ item }) => {
       value: creator,
       facet: reactiveSearchFacets.find((facet) => facet.value === "Creator"),
     },
-    { label: "Date", value: formatDate(createDate) },
+    { label: "Date", value: dateCreated.map((d) => d.humanized) },
     {
       label: "Department",
       value: libraryUnit.label,

--- a/src/testing-helpers/mock-work.js
+++ b/src/testing-helpers/mock-work.js
@@ -32,6 +32,16 @@ export const mockWork = {
     folderName: [],
     license: null,
     rightsHolder: [],
+    dateCreated: [
+      {
+        edtf: "~2021",
+        humanized: "circa 2021?",
+      },
+      {
+        edtf: "199X",
+        humanized: "1990s",
+      },
+    ],
     genre: [
       {
         displayFacet: "pointers (breed, dogs)",


### PR DESCRIPTION
<img width="397" alt="Screen Shot 2021-02-18 at 3 45 39 PM" src="https://user-images.githubusercontent.com/6372022/108432256-52865080-7201-11eb-9fc4-7f4111b7d6e1.png">
