### PR TITLE
Fix view all items in collection or library unit on work page

### DIFF
--- a/src/api/elasticsearch-api.js
+++ b/src/api/elasticsearch-api.js
@@ -52,7 +52,7 @@ async function search(query_hash, retries = 8) {
  * @param {Number} numResults
  * @returns {Array}
  */
-export async function getAdminSetItems(id, numResults = PAGE_SIZE) {
+export async function getLibraryUnitItems(id, numResults = PAGE_SIZE) {
   try {
     const response = await search({
       ...getObjBase,
@@ -70,14 +70,7 @@ export async function getAdminSetItems(id, numResults = PAGE_SIZE) {
                   },
                   {
                     match: {
-                      "admin_set.id": id,
-                    },
-                  },
-                ],
-                must_not: [
-                  {
-                    match: {
-                      "collection.top_level": false,
+                      "administrativeMetadata.libraryUnit.id": id,
                     },
                   },
                 ],
@@ -130,7 +123,6 @@ export async function getAllCollections(numResults = PAGE_SIZE) {
         },
       },
     });
-    console.log("getAllCollections() response", response);
     return response.hits.hits.map((hit) => ({ id: hit._id, ...hit._source }));
   } catch (error) {
     console.log("Error in getAllCollections", error);
@@ -171,7 +163,6 @@ export async function getCollectionsByKeyword(keyword, numResults = PAGE_SIZE) {
         ...sortKey,
       },
     });
-    console.log("getCollectionsByKeyword() response", response);
     return response.hits.hits.map((hit) => hit._source);
   } catch (error) {
     console.log("Error in getCollectionsByKeyword()", error);
@@ -199,7 +190,6 @@ export async function getCollectionItems(id, numResults = PAGE_SIZE) {
                   { match: { "model.name": "Image" } },
                   { match: { "collection.id": id } },
                 ],
-                must_not: { match: { "collection.top_level": false } },
               },
             },
             boost: "5",

--- a/src/components/Work/ParentCollections.js
+++ b/src/components/Work/ParentCollections.js
@@ -6,12 +6,14 @@ import SectionTop from "../UI/SectionTop";
 import { reactiveSearchFacets } from "../../services/reactive-search";
 
 const ParentCollections = ({ libraryUnitItems = [], collection, item }) => {
+  if (!item) return;
+
   const libraryDepartment = item.administrativeMetadata.libraryUnit
     ? item.administrativeMetadata.libraryUnit.label
     : "";
   return (
     <div>
-      {item && libraryUnitItems && libraryUnitItems.length > 0 && (
+      {libraryUnitItems.length > 0 && (
         <section className="section" data-testid="section-library-department">
           <SectionTop
             sectionTitle="Library Department"
@@ -33,7 +35,7 @@ const ParentCollections = ({ libraryUnitItems = [], collection, item }) => {
         </section>
       )}
 
-      {item && collection.items && collection.items.length > 0 && (
+      {collection.items && collection.items.length > 0 && (
         <section data-testid="section-collection">
           <SectionTop
             sectionTitle="Collection"

--- a/src/components/Work/ParentCollections.js
+++ b/src/components/Work/ParentCollections.js
@@ -5,33 +5,35 @@ import ThisItem from "./ThisItem";
 import SectionTop from "../UI/SectionTop";
 import { reactiveSearchFacets } from "../../services/reactive-search";
 
-const ParentCollections = ({ adminSetItems = [], collection, item }) => {
-  const adminSetTitle = item.admin_set ? item.admin_set.title[0] : "";
+const ParentCollections = ({ libraryUnitItems = [], collection, item }) => {
+  const libraryDepartment = item.administrativeMetadata.libraryUnit
+    ? item.administrativeMetadata.libraryUnit.label
+    : "";
   return (
     <div>
-      {item && adminSetItems.length > 0 && (
+      {item && libraryUnitItems && libraryUnitItems.length > 0 && (
         <section className="section" data-testid="section-library-department">
           <SectionTop
             sectionTitle="Library Department"
-            optionalSubhead={adminSetTitle}
+            optionalSubhead={libraryDepartment}
             optionalButtons={[
               {
                 label: "View All Items in Library Department",
                 url: "/search",
                 state: {
                   facet: reactiveSearchFacets.find(
-                    facet => facet.value === "LibraryDepartment"
+                    (facet) => facet.value === "LibraryDepartment"
                   ),
-                  searchValue: adminSetTitle
-                }
-              }
+                  searchValue: libraryDepartment,
+                },
+              },
             ]}
           />
-          <PhotoGrid items={adminSetItems} hideDescriptions={true} />
+          <PhotoGrid items={libraryUnitItems} hideDescriptions={true} />
         </section>
       )}
 
-      {item && collection.items.length > 0 && (
+      {item && collection.items && collection.items.length > 0 && (
         <section data-testid="section-collection">
           <SectionTop
             sectionTitle="Collection"
@@ -39,8 +41,8 @@ const ParentCollections = ({ adminSetItems = [], collection, item }) => {
             optionalButtons={[
               {
                 label: "View All Items in Collection",
-                url: `/collections/${collection.id}`
-              }
+                url: `/collections/${collection.id}`,
+              },
             ]}
           />
           <PhotoGrid items={collection.items} />
@@ -53,13 +55,13 @@ const ParentCollections = ({ adminSetItems = [], collection, item }) => {
 };
 
 ParentCollections.propTypes = {
-  adminSetItems: PropTypes.array.isRequired,
+  libraryUnitItems: PropTypes.array.isRequired,
   collection: PropTypes.shape({
     id: PropTypes.string,
     title: PropTypes.string,
-    items: PropTypes.array
+    items: PropTypes.array,
   }),
-  item: PropTypes.object.isRequired
+  item: PropTypes.object.isRequired,
 };
 
 export default ParentCollections;

--- a/src/components/Work/Tabs/Cite.js
+++ b/src/components/Work/Tabs/Cite.js
@@ -43,7 +43,7 @@ const TabsCite = ({ item }) => {
   const collectionTitle =
     Object.keys(collection).length === 0 ? "" : collection.title;
   const libraryUnitLabel = item.administrativeMetadata.libraryUnit
-    ? item.administrativeMetadata.libraryUnitLabel
+    ? item.administrativeMetadata.libraryUnit.label
     : "";
 
   const citePanel = [

--- a/src/components/Work/Tabs/Cite.js
+++ b/src/components/Work/Tabs/Cite.js
@@ -31,27 +31,27 @@ const flexTitle = css`
 `;
 
 const TabsCite = ({ item }) => {
-  const {
-    administrativeMetadata: { libraryUnit }, // = "Library Division"
-    collection,
-    createDate: [date] = "",
-    descriptiveMetadata,
-    id,
-    termsOfUse,
-  } = item;
+  const { collection, createDate: [date] = "", descriptiveMetadata, id } = item;
 
-  const { ark, identifier, license, title } = descriptiveMetadata;
+  const { ark, identifier, license, title, termsOfUse } = descriptiveMetadata;
 
   const [copied, setCopied] = useState();
 
   const nul = "Northwestern University Libraries";
   const itemLink = `${window.location.origin}/items/${id}`;
   const today = new Date().toDateString();
-  const collectionTitle = collection ? collection.title : "";
+  const collectionTitle =
+    Object.keys(collection).length === 0 ? "" : collection.title;
+  const libraryUnitLabel = item.administrativeMetadata.libraryUnit
+    ? item.administrativeMetadata.libraryUnitLabel
+    : "";
 
   const citePanel = [
     { label: "Identifier", value: identifier },
-    { label: "Licenses", value: license },
+    {
+      label: "License",
+      value: license ? license.label : "",
+    },
     { label: "Title", value: title },
     { label: "Use Statement", value: termsOfUse },
   ];
@@ -66,25 +66,25 @@ const TabsCite = ({ item }) => {
     {
       id: "apaFormat",
       label: "APA Format",
-      text: `${libraryUnit.label}, ${nul}. (${date}). ${title}, Retrieved from ${itemLink}`,
+      text: `${libraryUnitLabel}, ${nul}. (${date}). ${title}, Retrieved from ${itemLink}`,
       style: {},
     },
     {
       id: "turabianFormat",
       label: "Chicago/Turabian Format",
-      text: `${libraryUnit.label}, ${nul}. "${title}", ${collectionTitle} Accessed ${today}. ${itemLink}`,
+      text: `${libraryUnitLabel}, ${nul}. "${title}", ${collectionTitle} Accessed ${today}. ${itemLink}`,
       style: {},
     },
     {
       id: "mlaFormat",
       label: "MLA Format",
-      text: `${libraryUnit.label}, ${nul}. "${title}", ${collectionTitle} ${date}. ${window.location.origin}/items/${id}`,
+      text: `${libraryUnitLabel}, ${nul}. "${title}", ${collectionTitle} ${date}. ${window.location.origin}/items/${id}`,
       style: {},
     },
     {
       id: "wikiCitation",
       label: "Wikipedia Citation",
-      text: `<ref name=NUL>{{cite web | url=${itemLink} | title= ${title} (${date}) }} |author=Digital Collections, ${nul} |accessdate=${today} |publisher=${nul}, ${libraryUnit.label}}}</ref>`,
+      text: `<ref name=NUL>{{cite web | url=${itemLink} | title= ${title} (${date}) }} |author=Digital Collections, ${nul} |accessdate=${today} |publisher=${nul}, ${libraryUnitLabel}}}</ref>`,
       style: styles.monoSpace,
     },
   ];

--- a/src/components/Work/Tabs/Metadata.js
+++ b/src/components/Work/Tabs/Metadata.js
@@ -71,7 +71,7 @@ const TabsMetadata = ({ item }) => {
     { label: "Date", value: formatDate(createDate) },
     {
       label: "Department",
-      value: libraryUnit.label,
+      value: libraryUnit ? libraryUnit.label : "",
       facet: reactiveSearchFacets.find(
         (facet) => facet.value === "LibraryDepartment"
       ),

--- a/src/components/Work/Work.js
+++ b/src/components/Work/Work.js
@@ -9,7 +9,7 @@ import LargeFeature from "../../components/Work/LargeFeature";
 import PropTypes from "prop-types";
 
 const Work = ({ work }) => {
-  const [adminSetItems, setAdminSetItems] = useState([]);
+  const [libraryUnitItems, setLibraryUnitItems] = useState([]);
   const [collection, setCollection] = useState({
     id: "",
     title: "",
@@ -22,25 +22,25 @@ const Work = ({ work }) => {
       if (!work) {
         return;
       }
-      // TODO: Make this work
-      /*
-      const adminSetItems = await getAdminSets(work.admin_set.id);
-      let collectionResponse = await getCollections(work);
+      if (work.administrativeMetadata.libraryUnit) {
+        const libraryUnitItems = await getLibraryUnits(
+          work.administrativeMetadata.libraryUnit.id
+        );
+        setLibraryUnitItems(libraryUnitItems);
+      }
 
-      if (collectionResponse.items) {
+      let collectionResponse = await getCollections(work);
+      if (collectionResponse) {
         setCollection({ ...collectionResponse });
       }
 
-      setAdminSetItems(adminSetItems);
-
-      */
       setLoading(false);
     }
     getApiData();
   }, [work]);
 
-  async function getAdminSets(adminSetId) {
-    let sources = await elasticsearchApi.getAdminSetItems(adminSetId, 4);
+  async function getLibraryUnits(libraryUnitId) {
+    let sources = await elasticsearchApi.getLibraryUnitItems(libraryUnitId, 4);
 
     return elasticsearchParser.prepPhotoGridItems(
       sources,
@@ -49,22 +49,23 @@ const Work = ({ work }) => {
   }
 
   async function getCollections(work) {
-    if (work.collection.length === 0) {
+    if (Object.keys(work.collection).length === 0) {
       return {};
     }
 
     const sources = await elasticsearchApi.getCollectionItems(
-      work.collection[0].id,
+      work.collection.id,
       4
     );
+
     let items = elasticsearchParser.prepPhotoGridItems(
       sources,
       globalVars.IMAGE_MODEL
     );
 
     return {
-      id: work.collection[0].id,
-      title: elasticsearchParser.getESTitle(work.collection[0]),
+      id: work.collection.id,
+      title: work.collection.title,
       items,
     };
   }
@@ -75,7 +76,7 @@ const Work = ({ work }) => {
       <LoadingSpinner loading={loading} />
       <ParentCollections
         item={work}
-        adminSetItems={adminSetItems}
+        libraryUnitItems={libraryUnitItems}
         collection={collection}
       />
       <WorkItemDetail item={work} />

--- a/src/screens/Work/Work.js
+++ b/src/screens/Work/Work.js
@@ -101,8 +101,8 @@ const ScreensWork = () => {
       : [];
 
     const dataLayer = {
-      adminset: item.admin_set
-        ? item.admin_set.title.map((title) => title).join(", ")
+      adminset: item.administrativeMetadata.libraryUnit
+        ? item.administrativeMetadata.libraryUnit.label
         : "",
       // TODO: Will .collection be an object or array?
       // collections: item.collection.map(collection =>


### PR DESCRIPTION
- Restores "VIEW ALL ITEMS IN COLLECTION" and "VIEW ALL ITEMS IN LIBRARY DEPARTMENT"  on individual work page
- Attempts to deal with no collection or library department (to handle shared links cases (or batch update mistakes) with minimal metadata)
- Fixes display of Terms of Use and License on cite tab

resolves nulib/repodev_planning_and_docs#1495 ,
resolves nulib/repodev_planning_and_docs#1496
resolves nulib/repodev_planning_and_docs#587

<img width="1452" alt="Screen Shot 2021-02-19 at 7 43 34 AM" src="https://user-images.githubusercontent.com/6372022/108544189-5bc7f980-72a3-11eb-916a-94e9845d5004.png">

<img width="1291" alt="Screen Shot 2021-02-19 at 11 12 41 AM" src="https://user-images.githubusercontent.com/6372022/108544225-6aaeac00-72a3-11eb-8d25-fecfbc3a8f40.png">



<img width="1054" alt="Screen Shot 2021-02-19 at 11 07 11 AM" src="https://user-images.githubusercontent.com/6372022/108544159-4ce14700-72a3-11eb-9848-a9610fe9c930.png">
