### PR TITLE
Force DC to redirect to HTTPS

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -88,7 +88,7 @@ resource "aws_cloudfront_distribution" "fen" {
       }
     }
 
-    viewer_protocol_policy = "allow-all"
+    viewer_protocol_policy = "redirect-to-https"
     min_ttl                = 0
     default_ttl            = 3600
     max_ttl                = 86400


### PR DESCRIPTION
This is a terraform-only change that has already been applied to both staging and production