### PR TITLE
Update getLegacyPidItem in the elasticsearch-api to work with Meadow records

### DIFF
--- a/src/api/elasticsearch-api.js
+++ b/src/api/elasticsearch-api.js
@@ -261,7 +261,7 @@ export async function getLegacyPidItem(pid) {
             must: [
               {
                 match: {
-                  "legacy_identifier.keyword": pid,
+                  "descriptiveMetadata.legacyIdentifier.keyword": pid,
                 },
               },
             ],


### PR DESCRIPTION
- Updates the `getLegacyPidItem` query using the new Meadow indexed data structure for legacy identifiers.