### PR TITLE
Update default image JPG download to have accession number as its fil…

### DIFF
--- a/src/components/Work/Tabs/Download.js
+++ b/src/components/Work/Tabs/Download.js
@@ -95,7 +95,7 @@ const WorkTabsDownload = React.memo(function ({ item }) {
                 <td>
                   <ImageDownloader
                     imageUrl={`${row.id}/full/3000,/0/default.jpg`}
-                    imageTitle={row.label ? cleanupFilename(row.label) : ""}
+                    imageTitle={item?.accessionNumber || ""}
                     data-testid="download-button"
                     className="button-link"
                     iconColor="#4e2a84"


### PR DESCRIPTION
…ename instead of label

![image](https://user-images.githubusercontent.com/3020266/121234336-39a9b580-c859-11eb-8bb3-a488ad6599eb.png)
