### PR TITLE
Add work archiver endpoint environment variable

### DIFF
--- a/deploy/build
+++ b/deploy/build
@@ -5,6 +5,8 @@ export REACT_APP_DONUT_URL=$(aws ssm get-parameter --name /stack-glaze/react_app
 export REACT_APP_IIIF_LOGIN_URL=$(aws ssm get-parameter --name /stack-glaze/react_app_iiif_login_url | jq -r '.Parameter.Value')
 export REACT_APP_SHARED_ITEM_PROXY_URL=$(aws ssm get-parameter --name /stack-glaze/react_app_shared_item_proxy_url | jq -r '.Parameter.Value')
 S3_BUCKET=$(aws ssm get-parameter --name /dc/s3_bucket | jq -r '.Parameter.Value')
+export REACT_APP_WORK_ARCHIVER_ENDPOINT=$(aws ssm get-parameter --name /stack-glaze/react_app_work_archiver_endpoint | jq -r '.Parameter.Value')
+
 
 echo "REACT_APP_ELASTICSEARCH_PROXY_BASE=$REACT_APP_ELASTICSEARCH_PROXY_BASE REACT_APP_DONUT_URL=$REACT_APP_DONUT_URL REACT_APP_IIIF_LOGIN_URL=$REACT_APP_IIIF_LOGIN_URL REACT_APP_SHARED_ITEM_PROXY_URL=$REACT_APP_SHARED_ITEM_PROXY_URL S3_BUCKET=$S3_BUCKET"
 

--- a/src/services/global-vars.js
+++ b/src/services/global-vars.js
@@ -37,6 +37,9 @@ export const COLLECTION_MODEL = "Collection";
 export const HONEYBADGER_API_KEY = process.env.REACT_APP_HONEYBADGER_API_KEY;
 export const HONEYBADGER_ENV = process.env.REACT_APP_HONEYBADGER_ENV;
 
+export const WORK_ARCHIVER_ENDPOINT =
+  process.env.REACT_APP_WORK_ARCHIVER_ENDPOINT;
+
 export const SHARED_ITEM_PROXY_URL =
   process.env.REACT_APP_SHARED_ITEM_PROXY_URL ||
   "https://dcapi.stack.rdc-staging.library.northwestern.edu/resolve/";


### PR DESCRIPTION
To use in app:

```
import * as globalVars from "../../services/global-vars";
...
globalVars.WORK_ARCHIVER_ENDPOINT
```

This will unblock issue: https://github.com/nulib/repodev_planning_and_docs/issues/2115
Documentation on using the endpoint forthcoming. 
