### PR TITLE
Add textual indicator for work type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ npm-debug.log*
 
 # IDEs
 /.vscode
+.idea
 
 # Cypress End to End Testing
 /cypress/integration/examples

--- a/cypress/integration/collections/view_page_spec.js
+++ b/cypress/integration/collections/view_page_spec.js
@@ -118,7 +118,11 @@ describe("Collections View page", () => {
     context("Facet/filtering", () => {
       beforeEach(function () {
         //Get the first result;
-        cy.get(".rs-result-list article").first().invoke("text").as("txt");
+        cy.get(".rs-result-list article")
+          .first()
+          .find("h4")
+          .invoke("text")
+          .as("txt");
         //Get the number of search results text E.g., 113 results in 10 ms.
         cy.get(".rs-results-info").invoke("text").as("resultsTxt");
       });
@@ -147,6 +151,13 @@ describe("Collections View page", () => {
           .first()
           .find("h4")
           .should("have.text", this.txt);
+      });
+
+      it("should display the correct work type for each filtered photo box", function () {
+        // it should display the work type label
+        cy.getByTestId("work-type-photo-box").each((label) => {
+          expect(label.text()).to.be.oneOf(["AUDIO", "IMAGE", "VIDEO"]);
+        });
       });
     });
   });

--- a/cypress/integration/search_page_spec.js
+++ b/cypress/integration/search_page_spec.js
@@ -95,6 +95,13 @@ describe("Search page", () => {
             });
         });
       });
+
+      it("should display the correct work type for each filtered photo box", function () {
+        // it should display the work type label
+        cy.getByTestId("work-type-photo-box").each((label) => {
+          expect(label.text()).to.be.oneOf(["AUDIO", "IMAGE", "VIDEO"]);
+        });
+      });
     });
 
     context("Facet/filtering", () => {

--- a/src/components/UI/PhotoBox.test.tsx
+++ b/src/components/UI/PhotoBox.test.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import PhotoBox from "./PhotoBox";
+import { render, screen } from "@testing-library/react";
+import { renderWithRouter } from "services/@testing-library-helpers";
+
+describe("Photo box component", () => {
+  it("renders", () => {
+    renderWithRouter(
+      <PhotoBox
+        key="4dfdfb3b-d533-4757-99eb-f70b5c4c2d9d"
+        id="4dfdfb3b-d533-4757-99eb-f70b5c4c2d9d"
+        imageUrl="https://iiif.stack.rdc.library.northwestern.edu/iiif/2/72f52fc7-9db8-4c8e-a4d1-fd8ff364cd4d/square/500,500/0/default.jpg"
+        label="Towards Self-Government in Nigeria"
+        modelName="Image"
+        workType="IMAGE"
+      />
+    );
+    expect(screen.getByTestId("photo-box"));
+    expect(screen.getByTestId("img-photo-box")).toHaveAttribute("alt");
+    expect(screen.getByTestId("title-photo-box")).toHaveTextContent("Nigeria");
+    expect(screen.getByTestId("work-type-photo-box")).toHaveTextContent(
+      "IMAGE"
+    );
+  });
+});

--- a/src/components/UI/PhotoBox.tsx
+++ b/src/components/UI/PhotoBox.tsx
@@ -13,6 +13,13 @@ const lineHeight = css`
   lineheight: 1.5rem;
 `;
 
+const smallLabel = css`
+  display: flex-inline;
+  color: #716c6b;
+  font-size: 0.7222rem;
+  text-transform: capitalize;
+`;
+
 function buildImgSrc(
   imgUrl: string | undefined,
   workType: string,
@@ -78,6 +85,10 @@ const PhotoBox: React.FC<PhotoBoxProps> = ({
       {!hideDescriptions && description && (
         <p data-testid="description-photo-box">{chopString(description, 15)}</p>
       )}
+
+      <span data-testid="work-type-photo-box" css={smallLabel}>
+        {workType}
+      </span>
     </article>
   );
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "types": ["@emotion/core"],
+    "types": ["@emotion/core", "jest"],
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "baseUrl": "src",
@@ -18,5 +18,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"]
+  "include": ["src", "./src/setupTests.js"]
 }


### PR DESCRIPTION
This pull request adds a very basic textual indicator for the work type photobox. I decided against using an SVG as it seemed to detract from the visual interest of the thumbnail and did not feel much more additive on top of the text label. I intentionally placed the label outside of the article <Link> and gave it a subtle northwestern gray tone.

![image](https://user-images.githubusercontent.com/7376450/135867469-6ce212e3-5ed5-4c59-9334-c85bd46e6786.png)
