### PR TITLE
Modify Elasticsearch queries and helper functions to handle either 'Image' or 'Work' model names

### DIFF
--- a/src/api/__mocks__/elasticsearch-api.js
+++ b/src/api/__mocks__/elasticsearch-api.js
@@ -7,7 +7,7 @@ export async function getAdminSetItems(id) {
           _source: {
             model: {
               application: "Nextgen",
-              name: "Image",
+              name: "Work",
             },
             id: "92df48a4-344a-456b-b860-2b189c45a940",
             admin_set: {

--- a/src/api/elasticsearch-api.js
+++ b/src/api/elasticsearch-api.js
@@ -62,18 +62,16 @@ export async function getLibraryUnitItems(id, numResults = PAGE_SIZE) {
           function_score: {
             query: {
               bool: {
-                must: [
-                  {
-                    match: {
-                      "model.name": "Image",
-                    },
-                  },
-                  {
-                    match: {
-                      "administrativeMetadata.libraryUnit.id": id,
-                    },
-                  },
+                should: [
+                  { match: { "model.name": "Image" } },
+                  { match: { "model.name": "Work" } },
                 ],
+                minimum_should_match: 1,
+                must: {
+                  match: {
+                    "administrativeMetadata.libraryUnit.id": id,
+                  },
+                },
               },
             },
             boost: "5",
@@ -181,10 +179,12 @@ export async function getCollectionItems(id, numResults = PAGE_SIZE) {
           function_score: {
             query: {
               bool: {
-                must: [
+                should: [
                   { match: { "model.name": "Image" } },
-                  { match: { "collection.id": id } },
+                  { match: { "model.name": "Work" } },
                 ],
+                minimum_should_match: 1,
+                must: { match: { "collection.id": id } },
               },
             },
             boost: "5",
@@ -289,18 +289,16 @@ export async function getRecentlyDigitizedItems(numResults = PAGE_SIZE) {
         size: numResults,
         query: {
           bool: {
-            must: [
-              {
-                match: {
-                  "model.name": "Image",
-                },
-              },
-              {
-                match: {
-                  "model.application": "Meadow",
-                },
-              },
+            should: [
+              { match: { "model.name": "Image" } },
+              { match: { "model.name": "Work" } },
             ],
+            minimum_should_match: 1,
+            must: {
+              match: {
+                "model.application": "Meadow",
+              },
+            },
           },
         },
         ...sortKey,

--- a/src/components/Search/Search.js
+++ b/src/components/Search/Search.js
@@ -9,7 +9,7 @@ import LoadingSpinner from "../UI/LoadingSpinner";
 import {
   DATASEARCH_PLACEHOLDER,
   GLOBAL_SEARCH_BAR_COMPONENT_ID,
-  imagesOnlyDefaultQuery,
+  worksOnlyDefaultQuery,
   FACET_SENSORS_RIGHTS_USAGE,
   FACET_SENSORS_LOCATION,
   FACET_SENSORS_CREATOR,
@@ -135,7 +135,7 @@ const Search = ({ breadcrumbs = [] }) => {
             pagination: "rs-pagination",
             resultsInfo: "rs-results-info",
           }}
-          defaultQuery={imagesOnlyDefaultQuery}
+          defaultQuery={worksOnlyDefaultQuery}
           loader={<LoadingSpinner loading={true} />}
           renderItem={renderItem}
           pagination={true}

--- a/src/components/UI/FacetsSidebar.js
+++ b/src/components/UI/FacetsSidebar.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { useLocation, useParams } from "react-router-dom";
 import { ROUTES } from "services/global-vars";
 import {
-  imagesOnlyDefaultQuery,
+  worksOnlyDefaultQuery,
   collectionDefaultQuery,
   COLLECTION_ITEMS_SEARCH_BAR_COMPONENT_ID,
   FACET_SENSORS_RIGHTS_USAGE,
@@ -164,7 +164,7 @@ const FacetsSidebar = ({
   }
 
   const defaultMultiListProps = {
-    defaultQuery: isSearchPage() ? imagesOnlyDefaultQuery : collectionsQuery,
+    defaultQuery: isSearchPage() ? worksOnlyDefaultQuery : collectionsQuery,
     innerClass: multiListInnerClass,
     missingLabel: "None",
     showMissing: true,

--- a/src/components/UI/FeatureBox.tsx
+++ b/src/components/UI/FeatureBox.tsx
@@ -14,7 +14,7 @@ interface FeatureBoxProps {
 
 const FeatureBox: React.FC<FeatureBoxProps> = ({ item, modelType }) => {
   const { description, id, image, label } = item;
-  const urlHelper = modelType === "image" ? "/items" : "/collections";
+  const urlHelper = modelType === "collection" ? "/collections" : "/items";
 
   return (
     <article className="feature-box">

--- a/src/services/elasticsearch-parser.js
+++ b/src/services/elasticsearch-parser.js
@@ -7,7 +7,7 @@ export function buildImageUrl(
   iiifParams = globalVars.IIIF_MEDIUM_ITEM_REGION
 ) {
   const idKey =
-    modelType === globalVars.IMAGE_MODEL
+    modelType === globalVars.IMAGE_MODEL || modelType === globalVars.WORK_MODEL
       ? source.representativeFileSet
         ? source.representativeFileSet.url
         : ""
@@ -76,7 +76,11 @@ export function getESImagePath(
   if (_source.model && _source.model.name === globalVars.COLLECTION_MODEL) {
     imgUrl = _source.representativeImage ? _source.representativeImage.url : "";
   }
-  if (_source.model && _source.model.name === globalVars.IMAGE_MODEL) {
+  if (
+    _source.model &&
+    (_source.model.name === globalVars.IMAGE_MODEL ||
+      _source.model.name === globalVars.WORK_MODEL)
+  ) {
     imgUrl = _source.representativeFileSet
       ? _source.representativeFileSet.url
       : "";

--- a/src/services/global-vars.js
+++ b/src/services/global-vars.js
@@ -32,6 +32,7 @@ export const IIIF_LARGE_IMAGE_REGION =
   process.env.IIIF_LARGE_IMAGE_REGION || "/full/800,/0/default.jpg";
 
 export const IMAGE_MODEL = "Image";
+export const WORK_MODEL = "Work";
 export const COLLECTION_MODEL = "Collection";
 
 export const HONEYBADGER_API_KEY = process.env.REACT_APP_HONEYBADGER_API_KEY;

--- a/src/services/reactive-search.js
+++ b/src/services/reactive-search.js
@@ -163,11 +163,15 @@ export const simpleQueryStringQuery = (value = "*") => {
   };
 };
 
-export const imagesOnlyDefaultQuery = () => {
+export const worksOnlyDefaultQuery = () => {
   return {
     query: {
-      match: {
-        "model.name": "Image",
+      bool: {
+        should: [
+          { match: { "model.name": "Image" } },
+          { match: { "model.name": "Work" } },
+        ],
+        minimum_should_match: 1,
       },
     },
   };


### PR DESCRIPTION
Screenshots taken with `npm run start:use-real-data` demonstrating that current documents with `model.name = "Image"` still work:

![devbox library northwestern edu_3333_](https://user-images.githubusercontent.com/1395707/136042222-9b64dbdd-7f83-4e2a-a800-6fa9096b610e.png)

![devbox library northwestern edu_3333_search](https://user-images.githubusercontent.com/1395707/136042232-a13c6512-a01d-49a9-8157-bd96182415d4.png)
