### PR TITLE
Replace references to master branch with main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         run: npm run-script ci
   deploy:
     needs: test
-    if: ${{ (!github.event.pull_request) && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/deploy/') || startsWith(github.ref, 'refs/heads/build/')) }}
+    if: ${{ (!github.event.pull_request) && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/deploy/') || startsWith(github.ref, 'refs/heads/build/')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -34,7 +34,7 @@ jobs:
           node-version: "14"
       - name: Set DEPLOY_ENV from Branch Name
         run: |
-          if [[ $BRANCH == 'refs/heads/master' ]]; then
+          if [[ $BRANCH == 'refs/heads/main' ]]; then
             echo "DEPLOY_ENV=production" >> $GITHUB_ENV
           else
             echo "DEPLOY_ENV=$(echo $BRANCH | awk -F/ '{print $NF}')" >> $GITHUB_ENV

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 node {
   withCredentials([string(credentialsId: 'honeybadger-glaze', variable: 'api_key')]) {
     def tag_name = env.BRANCH_NAME.split('/').last()
-    if ( tag_name == "master" ) {
+    if ( tag_name == "main" ) {
       tag_name = "production"
     }
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ npm run test
 
 Merging a feature branch into the `deploy/staging` branch will automatically update the staging environment (https://dc.rdc-staging.library.northwestern.edu/)
 
-Merging `deploy/staging` into `master` will automatically update the production environment.
+Merging `deploy/staging` into `main` will automatically update the production environment.
 
 ## ADR
 


### PR DESCRIPTION
## Summary 

Replace references to master branch with main to support renaming branch `master` to `main`

Fixes https://github.com/nulib/repodev_planning_and_docs/issues/1884

## Specific Changes in this PR
- update GitHub Actions build
- update Jenkins build config
- update readme

## Steps to Test

Developers need to run the following in order to update their local git branchs

```
git fetch --prune -a
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```