### PR TITLE
Break word on long Work titles. :abcd:

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@fortawesome/fontawesome-svg-core": "^1.2.36",
         "@fortawesome/free-solid-svg-icons": "^5.15.4",
         "@fortawesome/react-fontawesome": "^0.1.15",
-        "@nulib/react-media-player": "^1.0.4",
+        "@nulib/react-media-player": "^1.4.5",
         "@reglendo/canvas2image": "^1.0.5-2",
         "@samvera/image-downloader": "^1.1.0",
         "cookie": "^0.4.0",
@@ -3388,9 +3388,9 @@
       "dev": true
     },
     "node_modules/@nulib/react-media-player": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.2.1.tgz",
-      "integrity": "sha512-wJzb2e/H0aV0qxNT+Oxcwe+7rBcr41aMjNLTHjlvbCs2qZV75xx3TW/DPdH3O3+V3NBoCOqIj6rOXqy4lJaDeg==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.4.5.tgz",
+      "integrity": "sha512-ffkfxVDK1Qw06vIbZCfnWuepH7O7/tmjKTr2XjeAC9OHonuy9dtI4qhHB0OofSB+9aZ9xmADIc41UYF9e1P1Rg==",
       "dependencies": {
         "@hyperion-framework/parser": "^1.0.0",
         "@hyperion-framework/types": "^1.0.0",
@@ -3399,17 +3399,14 @@
         "@radix-ui/react-radio-group": "^0.1.1",
         "@radix-ui/react-tabs": "^0.1.1",
         "@stitches/react": "^1.2.0",
-        "@types/jest": "^27.0.2",
+        "@types/openseadragon": "^2.4.8",
         "@types/react": "^17.0.21",
         "@types/react-dom": "^17.0.9",
+        "hls.js": "^1.0.10",
+        "openseadragon": "^2.4.2",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
-        "subtitles-parser-vtt": "^0.1.0",
-        "typescript": "^4.4.3"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0"
+        "subtitles-parser-vtt": "^0.1.0"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -4272,6 +4269,7 @@
       "version": "27.0.2",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.2.tgz",
       "integrity": "sha512-4dRxkS/AFX0c5XW6IPMNOydLn2tEhNhJV7DnYK+0bjoJZ+QTmfucBlihX7aoEsh/ocYtkLC73UbnBXBXIxsULA==",
+      "dev": true,
       "dependencies": {
         "jest-diff": "^27.0.0",
         "pretty-format": "^27.0.0"
@@ -4301,6 +4299,11 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
+    },
+    "node_modules/@types/openseadragon": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@types/openseadragon/-/openseadragon-2.4.8.tgz",
+      "integrity": "sha512-vPmpmigVdMYgdPJLUbQJgpFIQCeRnoUQW4bT/l9u1yajJLSx2BUKFhURvdTDxJWYFA/+oqMeXfJl2/NLhPZq7A=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -8309,6 +8312,7 @@
       "version": "27.0.6",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.6.tgz",
       "integrity": "sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==",
+      "dev": true,
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
@@ -11539,6 +11543,11 @@
         "value-equal": "^1.0.1"
       }
     },
+    "node_modules/hls.js": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.1.1.tgz",
+      "integrity": "sha512-2VEVzO/gr5LOD6K/DEmBkKEary6hr4YZ/SLb0PV81jOAM/Tl9DviL0sFMoUHDq05/j4OZxIj691Zo0p40u3Gtw=="
+    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -13353,6 +13362,7 @@
       "version": "27.3.1",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.3.1.tgz",
       "integrity": "sha512-PCeuAH4AWUo2O5+ksW4pL9v5xJAcIKPUPfIhZBcG1RKv/0+dvaWTQK1Nrau8d67dp65fOqbeMdoil+6PedyEPQ==",
+      "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "diff-sequences": "^27.0.6",
@@ -13367,6 +13377,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -13678,6 +13689,7 @@
       "version": "27.3.1",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.3.1.tgz",
       "integrity": "sha512-+Ilqi8hgHSAdhlQ3s12CAVNd8H96ZkQBfYoXmArzZnOfAtVAJEiPDBirjByEblvG/4LPJmkL+nBqPO3A1YJAEg==",
+      "dev": true,
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
@@ -18977,6 +18989,7 @@
       "version": "27.3.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.3.1.tgz",
       "integrity": "sha512-DR/c+pvFc52nLimLROYjnXPtolawm+uWDxr4FjuLDLUn+ktWnSN851KoHwHzzqq6rfCOjkzN8FLgDrSub6UDuA==",
+      "dev": true,
       "dependencies": {
         "@jest/types": "^27.2.5",
         "ansi-regex": "^5.0.1",
@@ -18991,6 +19004,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -19001,7 +19015,8 @@
     "node_modules/pretty-format/node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
     },
     "node_modules/process": {
       "version": "0.11.10",
@@ -28522,9 +28537,9 @@
       "dev": true
     },
     "@nulib/react-media-player": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.2.1.tgz",
-      "integrity": "sha512-wJzb2e/H0aV0qxNT+Oxcwe+7rBcr41aMjNLTHjlvbCs2qZV75xx3TW/DPdH3O3+V3NBoCOqIj6rOXqy4lJaDeg==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.4.5.tgz",
+      "integrity": "sha512-ffkfxVDK1Qw06vIbZCfnWuepH7O7/tmjKTr2XjeAC9OHonuy9dtI4qhHB0OofSB+9aZ9xmADIc41UYF9e1P1Rg==",
       "requires": {
         "@hyperion-framework/parser": "^1.0.0",
         "@hyperion-framework/types": "^1.0.0",
@@ -28533,13 +28548,14 @@
         "@radix-ui/react-radio-group": "^0.1.1",
         "@radix-ui/react-tabs": "^0.1.1",
         "@stitches/react": "^1.2.0",
-        "@types/jest": "^27.0.2",
+        "@types/openseadragon": "^2.4.8",
         "@types/react": "^17.0.21",
         "@types/react-dom": "^17.0.9",
+        "hls.js": "^1.0.10",
+        "openseadragon": "^2.4.2",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
-        "subtitles-parser-vtt": "^0.1.0",
-        "typescript": "^4.4.3"
+        "subtitles-parser-vtt": "^0.1.0"
       }
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
@@ -28828,7 +28844,8 @@
     "@stitches/react": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@stitches/react/-/react-1.2.5.tgz",
-      "integrity": "sha512-95Wwjp5cvoYQjg616OBiHZM1PnIF51pnFQIgSPxPzS/xXBrer9sNO1tfpVfLYfOifvuotse2IFNbypJ92BXzvg=="
+      "integrity": "sha512-95Wwjp5cvoYQjg616OBiHZM1PnIF51pnFQIgSPxPzS/xXBrer9sNO1tfpVfLYfOifvuotse2IFNbypJ92BXzvg==",
+      "requires": {}
     },
     "@surma/rollup-plugin-off-main-thread": {
       "version": "1.4.2",
@@ -29173,6 +29190,7 @@
       "version": "27.0.2",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.2.tgz",
       "integrity": "sha512-4dRxkS/AFX0c5XW6IPMNOydLn2tEhNhJV7DnYK+0bjoJZ+QTmfucBlihX7aoEsh/ocYtkLC73UbnBXBXIxsULA==",
+      "dev": true,
       "requires": {
         "jest-diff": "^27.0.0",
         "pretty-format": "^27.0.0"
@@ -29202,6 +29220,11 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
+    },
+    "@types/openseadragon": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@types/openseadragon/-/openseadragon-2.4.8.tgz",
+      "integrity": "sha512-vPmpmigVdMYgdPJLUbQJgpFIQCeRnoUQW4bT/l9u1yajJLSx2BUKFhURvdTDxJWYFA/+oqMeXfJl2/NLhPZq7A=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -29698,7 +29721,8 @@
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -29758,12 +29782,14 @@
     "ajv-errors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "requires": {}
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -30273,7 +30299,8 @@
     "babel-plugin-named-asset-import": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.7.tgz",
-      "integrity": "sha512-squySRkf+6JGnvjoUtDEjSREJEBirnXi9NqP6rjSYsylxQxqBTz+pkmf395i9E2zsvmYUaI40BHo6SqZUdydlw=="
+      "integrity": "sha512-squySRkf+6JGnvjoUtDEjSREJEBirnXi9NqP6rjSYsylxQxqBTz+pkmf395i9E2zsvmYUaI40BHo6SqZUdydlw==",
+      "requires": {}
     },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.2.3",
@@ -32421,7 +32448,8 @@
     "diff-sequences": {
       "version": "27.0.6",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.6.tgz",
-      "integrity": "sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ=="
+      "integrity": "sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==",
+      "dev": true
     },
     "diffie-hellman": {
       "version": "5.0.3",
@@ -32606,7 +32634,8 @@
     "downshift": {
       "version": "1.31.16",
       "resolved": "https://registry.npmjs.org/downshift/-/downshift-1.31.16.tgz",
-      "integrity": "sha512-RskXmiGSoz0EHAyBrmTBGSLHg6+NYDGuLu2W3GpmuOe6hmZEWhCiQrq5g6DWzhnUaJD41xHbbfC6j1Fe86YqgA=="
+      "integrity": "sha512-RskXmiGSoz0EHAyBrmTBGSLHg6+NYDGuLu2W3GpmuOe6hmZEWhCiQrq5g6DWzhnUaJD41xHbbfC6j1Fe86YqgA==",
+      "requires": {}
     },
     "duplexer": {
       "version": "0.1.2",
@@ -33120,7 +33149,8 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
       "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-config-react-app": {
       "version": "6.0.0",
@@ -33332,7 +33362,8 @@
     "eslint-plugin-react-hooks": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
-      "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA=="
+      "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
+      "requires": {}
     },
     "eslint-plugin-testing-library": {
       "version": "3.10.2",
@@ -34863,6 +34894,11 @@
         "value-equal": "^1.0.1"
       }
     },
+    "hls.js": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.1.1.tgz",
+      "integrity": "sha512-2VEVzO/gr5LOD6K/DEmBkKEary6hr4YZ/SLb0PV81jOAM/Tl9DviL0sFMoUHDq05/j4OZxIj691Zo0p40u3Gtw=="
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -36235,6 +36271,7 @@
       "version": "27.3.1",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.3.1.tgz",
       "integrity": "sha512-PCeuAH4AWUo2O5+ksW4pL9v5xJAcIKPUPfIhZBcG1RKv/0+dvaWTQK1Nrau8d67dp65fOqbeMdoil+6PedyEPQ==",
+      "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "diff-sequences": "^27.0.6",
@@ -36246,6 +36283,7 @@
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -36495,7 +36533,8 @@
     "jest-get-type": {
       "version": "27.3.1",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.3.1.tgz",
-      "integrity": "sha512-+Ilqi8hgHSAdhlQ3s12CAVNd8H96ZkQBfYoXmArzZnOfAtVAJEiPDBirjByEblvG/4LPJmkL+nBqPO3A1YJAEg=="
+      "integrity": "sha512-+Ilqi8hgHSAdhlQ3s12CAVNd8H96ZkQBfYoXmArzZnOfAtVAJEiPDBirjByEblvG/4LPJmkL+nBqPO3A1YJAEg==",
+      "dev": true
     },
     "jest-haste-map": {
       "version": "26.6.2",
@@ -36929,7 +36968,8 @@
     "jest-pnp-resolver": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
-      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w=="
+      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -40703,6 +40743,7 @@
       "version": "27.3.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.3.1.tgz",
       "integrity": "sha512-DR/c+pvFc52nLimLROYjnXPtolawm+uWDxr4FjuLDLUn+ktWnSN851KoHwHzzqq6rfCOjkzN8FLgDrSub6UDuA==",
+      "dev": true,
       "requires": {
         "@jest/types": "^27.2.5",
         "ansi-regex": "^5.0.1",
@@ -40713,12 +40754,14 @@
         "ansi-styles": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
         },
         "react-is": {
           "version": "17.0.2",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true
         }
       }
     },
@@ -40977,7 +41020,8 @@
     "react-collapsible": {
       "version": "2.8.4",
       "resolved": "https://registry.npmjs.org/react-collapsible/-/react-collapsible-2.8.4.tgz",
-      "integrity": "sha512-oG4yOk6AGKswe0OD/8t3/nf4Rgj4UhlZUUvqL5jop0/ez02B3dBDmNvs3sQz0PcTpJvt0ai8zF7Atd1SzN/UNw=="
+      "integrity": "sha512-oG4yOk6AGKswe0OD/8t3/nf4Rgj4UhlZUUvqL5jop0/ez02B3dBDmNvs3sQz0PcTpJvt0ai8zF7Atd1SzN/UNw==",
+      "requires": {}
     },
     "react-copy-to-clipboard": {
       "version": "5.0.4",
@@ -41269,7 +41313,8 @@
     "react-obfuscate": {
       "version": "3.6.8",
       "resolved": "https://registry.npmjs.org/react-obfuscate/-/react-obfuscate-3.6.8.tgz",
-      "integrity": "sha512-Pc47sbOJEGqOQ65y22ZFwCGHlSwGn0tykl+sQ64wHy/ALcyZxK6zsNYD8Fp3YBcU2EhmJPSKR7BypBYtnAqqyA=="
+      "integrity": "sha512-Pc47sbOJEGqOQ65y22ZFwCGHlSwGn0tykl+sQ64wHy/ALcyZxK6zsNYD8Fp3YBcU2EhmJPSKR7BypBYtnAqqyA==",
+      "requires": {}
     },
     "react-redux": {
       "version": "7.2.6",
@@ -41478,7 +41523,8 @@
     "react-side-effect": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
-      "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ=="
+      "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
+      "requires": {}
     },
     "react-sizes": {
       "version": "2.0.0",
@@ -41684,7 +41730,8 @@
     "redux-thunk": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.0.tgz",
-      "integrity": "sha512-/y6ZKQNU/0u8Bm7ROLq9Pt/7lU93cT0IucYMrubo89ENjxPa7i8pqLKu6V4X7/TvYovQ6x01unTeyeZ9lgXiTA=="
+      "integrity": "sha512-/y6ZKQNU/0u8Bm7ROLq9Pt/7lU93cT0IucYMrubo89ENjxPa7i8pqLKu6V4X7/TvYovQ6x01unTeyeZ9lgXiTA==",
+      "requires": {}
     },
     "regenerate": {
       "version": "1.4.2",
@@ -46204,7 +46251,8 @@
     "ws": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-      "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w=="
+      "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
+      "requires": {}
     },
     "xdate": {
       "version": "0.8.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/react-fontawesome": "^0.1.15",
-    "@nulib/react-media-player": "^1.0.4",
+    "@nulib/react-media-player": "^1.4.5",
     "@reglendo/canvas2image": "^1.0.5-2",
     "@samvera/image-downloader": "^1.1.0",
     "cookie": "^0.4.0",

--- a/src/styles/sass/nulib-collections/mixins/_photo-grid.scss
+++ b/src/styles/sass/nulib-collections/mixins/_photo-grid.scss
@@ -11,6 +11,7 @@
 
         > span {
           font-family: inherit !important;
+          word-break: break-word;
         }
       }
 

--- a/src/styles/sass/nulib-collections/page-types/landing-page/_large-feature.scss
+++ b/src/styles/sass/nulib-collections/page-types/landing-page/_large-feature.scss
@@ -7,6 +7,7 @@
         @include substitute-display;
         font-weight: 700;
         line-height: 1.1em;
+        word-break: break-word;
       }
 
       .text {


### PR DESCRIPTION
## Summary 
This fixes the issue of long work titles overflowing into their adjacent photo boxes. Long titles will now wrap by breaking the word. Words will only break if they happen to be wider than the computed width of the photo box article area. This fix will address all uses of work tiles (and collection titles) in photo boxes.

### Before
![image](https://user-images.githubusercontent.com/7376450/142644326-86ae02e9-7737-42bf-911b-5e03e9a3db7b.png)

### After
![image](https://user-images.githubusercontent.com/7376450/142644252-dd238d22-1896-493b-8523-5c0a687f525c.png)

This fix has also been applied to the work title in "large feature" area on a specific work.

## Specific Changes in this PR
- Fixes overflow on photo-box title
- Fixes overflow on large feature title

## Steps to Test
Go to the Rob Linrothe collection and review long titles there. Review any work there that has long titles. You may need to manually edit titles using Inspect if your local DC does not have them in real data.

![image](https://user-images.githubusercontent.com/7376450/142644853-001902fd-7745-4a1c-8c87-b8eaea3f17bc.png)

