### PR TITLE
First step to optimizing Search page

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,4 @@
 {
   "baseUrl": "https://devbox.library.northwestern.edu:3333/",
-  "defaultCommandTimeout": 8000
+  "defaultCommandTimeout": 15000
 }

--- a/cypress/integration/collections/view_page_spec.js
+++ b/cypress/integration/collections/view_page_spec.js
@@ -132,7 +132,7 @@ describe("Collections View page", () => {
         cy.getByTestId("facets-sidebar").within(($sidebar) => {
           cy.contains("Location")
             .siblings("ul")
-            .contains("France--Paris")
+            .contains("England--London")
             .click();
         });
 

--- a/src/components/UI/FacetsSidebar.js
+++ b/src/components/UI/FacetsSidebar.js
@@ -121,41 +121,6 @@ const FacetsSidebar = ({
     return [...allFilters, searchBarComponentId];
   };
 
-  // Return all connected facets for regular metadata
-  const filterList = (filterId) => {
-    let filtersMinusCurrent = facetSensors.filter(
-      (filterItem) => filterItem !== filterId
-    );
-    return [
-      ...filtersMinusCurrent,
-      ...facetSensorsCreator,
-      ...facetSensorsDescriptive,
-      searchBarComponentId,
-    ];
-  };
-  const filterCreatorList = (filterId) => {
-    let filtersMinusCurrent = facetSensorsCreator.filter(
-      (filterItem) => filterItem !== filterId
-    );
-    return [
-      ...filtersMinusCurrent,
-      ...facetSensors,
-      ...facetSensorsDescriptive,
-      searchBarComponentId,
-    ];
-  };
-  const filterDescriptiveList = (filterId) => {
-    let filtersMinusCurrent = facetSensorsDescriptive.filter(
-      (filterItem) => filterItem !== filterId
-    );
-    return [
-      ...filtersMinusCurrent,
-      ...facetSensors,
-      ...facetSensorsCreator,
-      searchBarComponentId,
-    ];
-  };
-
   function getDefaultValue(sensor) {
     if (!externalFacet && !searchValue) {
       return [];
@@ -168,7 +133,7 @@ const FacetsSidebar = ({
     innerClass: multiListInnerClass,
     missingLabel: "None",
     showMissing: true,
-    size: 500,
+    size: 100,
   };
 
   return (

--- a/src/services/reactive-search.js
+++ b/src/services/reactive-search.js
@@ -6,7 +6,7 @@ export const DATASEARCH_PLACEHOLDER =
 
 const defaultListItemValues = {
   showSearch: true,
-  sortBy: "asc",
+  sortBy: "count",
   URLParams: true,
 };
 


### PR DESCRIPTION
Change faceted results retrieved from 500 to 100.  Sort by count rather than ascending order.

## Summary 
This is step 1 in trying to optimize the Search page from being super slow

## Specific Changes in this PR
- Reduced faceted items pulled from ElasticSearch for each facet from 500 to 100
- Order by count, instead of asc
- Updated Cypress default timeout.  Slowness is causing integration tests to fail, locally at least.

## Steps to Test
Go to the Search page, and scroll through facet values.  There should be no more than 100 populated.  Also the load time should be slightly better.

Also please let developers know if there are any special instructions to test this in the development environment. 