### PR TITLE
Support displaying Notes metadata field

### DIFF
--- a/src/components/Work/MetadataDisplay.js
+++ b/src/components/Work/MetadataDisplay.js
@@ -12,6 +12,10 @@ function prepItemText(item) {
   if (item.label) {
     return item.label.label;
   }
+  // For Notes metadata field
+  if (item.note) {
+    return `${item.type.label} - ${item.note}`;
+  }
   return item;
 }
 
@@ -74,10 +78,12 @@ const MetadataDisplay = ({
       text = prepItemText(item);
     }
 
+    // Provide a link to Search on facet value which populates a new search
     if (facet) {
       return <li key={text}>{linkElement(facet, text)}</li>;
     }
 
+    // Link to an external URL outside our app
     if (externalUrlLabels.indexOf(title) > -1) {
       return (
         <li key={text}>
@@ -96,6 +102,10 @@ const MetadataDisplay = ({
           </a>
         </li>
       );
+    }
+
+    if (title === "Notes") {
+      return <li key={text}>{text}</li>;
     }
 
     return <li key={text}>{text}</li>;


### PR DESCRIPTION
## Summary 
Support displaying Notes metadata field

![image](https://user-images.githubusercontent.com/3020266/144911094-fde7c248-fdfc-4436-a6a4-221477473305.png)


## Specific Changes in this PR
- updated the `MetadataDisplay` component to "know" about the new `Notes` metadata field, which has a different shape than other metadata.
- Notes will now display in the Work's About tab next to other metadata.

## Steps to Test
1. Start up DC locally against staging: `npm run start:use-staging-data`
2. In Meadow Staging, add Notes to a Work
3. In your local DC dev environment, search for that work, and notice the Notes values pull through on the Work's About tab.

Also please let developers know if there are any special instructions to test this in the development environment. 