### PR TITLE
Include responsive bug fixes to a/v iiif media player.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@fortawesome/fontawesome-svg-core": "^1.2.36",
         "@fortawesome/free-solid-svg-icons": "^5.15.4",
         "@fortawesome/react-fontawesome": "^0.1.15",
-        "@nulib/react-media-player": "^1.6.0",
+        "@nulib/react-media-player": "^1.6.1",
         "@reglendo/canvas2image": "^1.0.5-2",
         "@samvera/image-downloader": "^1.1.0",
         "cookie": "^0.4.0",
@@ -3403,9 +3403,9 @@
       "dev": true
     },
     "node_modules/@nulib/react-media-player": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.6.0.tgz",
-      "integrity": "sha512-aq41sjQuriRs5XowbJaYn/L3VhSznC4BzqrEKB4Q2NtH+JU0puGBRLd4PHiyfE0I1Yg02Wsdeit2XZfL7UqoEQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.6.1.tgz",
+      "integrity": "sha512-rpW1SSLs7b3+K1ejyfJwnW0ZG6/JCUXRe6BGhM+gDRAWNMysEA9Vg0rVzv6mAaQxX9x2golRtAd3SGYY90if+w==",
       "dependencies": {
         "@hyperion-framework/parser": "^1.0.0",
         "@hyperion-framework/types": "^1.0.0",
@@ -29095,9 +29095,9 @@
       "dev": true
     },
     "@nulib/react-media-player": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.6.0.tgz",
-      "integrity": "sha512-aq41sjQuriRs5XowbJaYn/L3VhSznC4BzqrEKB4Q2NtH+JU0puGBRLd4PHiyfE0I1Yg02Wsdeit2XZfL7UqoEQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.6.1.tgz",
+      "integrity": "sha512-rpW1SSLs7b3+K1ejyfJwnW0ZG6/JCUXRe6BGhM+gDRAWNMysEA9Vg0rVzv6mAaQxX9x2golRtAd3SGYY90if+w==",
       "requires": {
         "@hyperion-framework/parser": "^1.0.0",
         "@hyperion-framework/types": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/react-fontawesome": "^0.1.15",
-    "@nulib/react-media-player": "^1.6.0",
+    "@nulib/react-media-player": "^1.6.1",
     "@reglendo/canvas2image": "^1.0.5-2",
     "@samvera/image-downloader": "^1.1.0",
     "cookie": "^0.4.0",


### PR DESCRIPTION
## Summary 
Bumps React Media Player to include responsive updates in https://github.com/nulib/react-media-player/pull/46.

## Specific Changes in this PR
- Includes bug fixes for zIndex, scroll overflow, and cue flex behavior.