### PR TITLE
2494 homepage fields

### DIFF
--- a/src/components/Home/Home.tsx
+++ b/src/components/Home/Home.tsx
@@ -39,13 +39,13 @@ const Home = () => {
     // Combine async network requests
     promises.push(getGalleryItems());
     promises.push(getFeaturedCollections());
-    globalVars.HOMEPAGE_COLLECTION_GROUP_KEYWORDS.forEach((keyword) =>
-      promises.push(getGalleryByKeyword(keyword))
+    promises.push(
+      getGalleryByKeywords(globalVars.HOMEPAGE_COLLECTION_GROUP_KEYWORDS)
     );
 
     // Put results on component state
     Promise.all(promises)
-      .then(([galleryItems, featuredCollections, ...keywordCollections]) => {
+      .then(([galleryItems, featuredCollections, keywordCollections]) => {
         setGalleryItems(galleryItems);
         setFeaturedCollections(featuredCollections);
         setKeywordCollections(keywordCollections);
@@ -63,7 +63,6 @@ const Home = () => {
       ) {
         return null;
       }
-
       return (
         <section
           className="section"
@@ -107,15 +106,16 @@ const Home = () => {
   }
 
   /**
-   * Get collections by keyword
+   * Get collections by keywords
    */
-  async function getGalleryByKeyword(keyword: string) {
-    let response = await elasticsearchApi.getCollectionsByKeyword(keyword);
-
-    const items = elasticsearchParser.prepPhotoGridItems(
-      response,
-      globalVars.COLLECTION_MODEL
-    );
+  async function getGalleryByKeywords(keywords: string[]) {
+    let response = await elasticsearchApi.getCollectionsByKeywords(keywords);
+    const items = response.map((item: any) => {
+      return elasticsearchParser.prepPhotoGridItems(
+        item.hits,
+        globalVars.COLLECTION_MODEL
+      );
+    });
 
     return items;
   }

--- a/src/components/Work/Tabs/Download.js
+++ b/src/components/Work/Tabs/Download.js
@@ -28,6 +28,8 @@ const WorkTabsDownload = React.memo(function ({ item }) {
   const [currentId, setCurrentId] = useState();
   const [currentLabel, setCurrentLabel] = useState();
 
+  console.log(item.representativeFileSet.url);
+
   const iiifServerUrl = item.representativeFileSet.url.slice(
     0,
     item.representativeFileSet.url.lastIndexOf("/")
@@ -58,6 +60,7 @@ const WorkTabsDownload = React.memo(function ({ item }) {
       .split("%2F")
       .join("");
 
+    console.log(row);
     setCurrentId(parsedId);
     setCurrentLabel(row.label);
     setModalOpen(true);

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -85,7 +85,7 @@ export function getTileSources(manifest) {
         const resource = canvas.items[0].items[0].body;
         if (resource.type !== "image" && resource.service) {
           tileSources.push({
-            id: resource["id"],
+            id: resource.service[0]["id"],
             label: canvas.label.en[0],
           });
         }


### PR DESCRIPTION
## Summary 
This pull request makes our elastic search responses on the homepage a little leaner. Only the fields required for building the sliders are now included in responses. In addition, the keyword based requests are now merged into a single request using `collapse`.

#### Note
I also included a single line fix for a small bug introduced in https://github.com/nulib/digital-collections/pull/953

## Specific Changes in this PR
- Updates `_source` fields requested to be specific to those required for building homepage
- Merges keyword request into a single query
- Bug fix for `</> HTML Embed` modal on A/V works

## Steps to Test
Homepage requests should return leaner responses. Other than verifying that the homepage renders as expected, the easiest way to test this is likely to `console.log()` those responses.

To test the bug fix noted above:
1. `npm run start:use-staging-data`
2. Go to an A/V work, click Download and Share
3. The `src` attribute in the HTML Tag code on  `</> HTML Embed` modal should respond with working IIIF image.

Also please let developers know if there are any special instructions to test this in the development environment. 