### PR TITLE
Add work type conditional IIIF viewer for shared items.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,7 @@
   "extends": ["plugin:react/recommended", "prettier"],
   "plugins": ["react", "prettier"],
   "parserOptions": {
-    "ecmaVersion": 7,
+    "ecmaVersion": "latest",
     "sourceType": "module",
     "ecmaFeatures": {
       "jsx": true

--- a/src/components/SharedItem/SharedItem.js
+++ b/src/components/SharedItem/SharedItem.js
@@ -1,15 +1,23 @@
 import React from "react";
 import PropTypes from "prop-types";
-import OpenSeadragonContainer from "../../screens/Work/OpenSeadragonContainer";
-import Work from "../Work/Work";
-
+import OpenSeadragonContainer from "screens/Work/OpenSeadragonContainer";
+import useWorkType from "hooks/use-work-type";
+import WorkMediaPlayerWrapper from "components/Work/MediaPlayer/Wrapper";
+import Work from "components/Work/Work";
 function SharedItem({ work }) {
-  if (!work) {
-    return null;
-  }
+  const { isMediaType } = useWorkType();
+
+  if (!work) return null;
+
   return (
     <div data-testid="shared-item">
-      <OpenSeadragonContainer item={work} />
+      {work && !isMediaType(work.workType) && (
+        <OpenSeadragonContainer item={work} />
+      )}
+      {work && isMediaType(work.workType) && (
+        <WorkMediaPlayerWrapper manifestId={work.iiifManifest} />
+      )}
+
       <div id="page">
         <main id="main-content" className="content" tabIndex="0">
           <Work work={work} />

--- a/src/components/SharedItem/SharedItem.test.js
+++ b/src/components/SharedItem/SharedItem.test.js
@@ -1,27 +1,32 @@
 import React from "react";
 import SharedItem from "./SharedItem";
 import { renderWithReduxAndRouter } from "../../services/@testing-library-helpers";
-import { mockWork } from "../../testing-helpers/mock-work";
+import { screen } from "@testing-library/react";
+import { mockWork } from "testing-helpers/mock-work";
+import { mockWorkVideo } from "testing-helpers/mock-work-video";
 
-xdescribe("SharedItem component", () => {
-  it("renders without crashing", () => {
-    const { getByTestId } = renderWithReduxAndRouter(
-      <SharedItem work={mockWork} />
-    );
-    expect(getByTestId("shared-item"));
+describe("SharedItem component", () => {
+  it("renders without crashing", async () => {
+    renderWithReduxAndRouter(<SharedItem work={mockWork} />);
+    const el = await screen.findByTestId("shared-item");
+    expect(el);
   });
 
-  it("renders the OpenSeadragon Viewer", () => {
-    const { getByTestId } = renderWithReduxAndRouter(
-      <SharedItem work={mockWork} />
-    );
-    expect(getByTestId("section-open-seadragon"));
+  it("renders the OpenSeadragon Viewer for an Image work", async () => {
+    renderWithReduxAndRouter(<SharedItem work={mockWork} />);
+    const el = await screen.findByTestId("section-open-seadragon");
+    expect(el);
   });
 
-  it("renders a Work component", () => {
-    const { getByTestId } = renderWithReduxAndRouter(
-      <SharedItem work={mockWork} />
-    );
-    expect(getByTestId("work-component"));
+  it("renders the React Media Player for a Video work", async () => {
+    renderWithReduxAndRouter(<SharedItem work={mockWorkVideo} />);
+    const el = await screen.findByTestId("media-player-wrapper");
+    expect(el);
+  });
+
+  it("renders a Work component", async () => {
+    renderWithReduxAndRouter(<SharedItem work={mockWork} />);
+    const el = await screen.findByTestId("work-component");
+    expect(el);
   });
 });

--- a/src/testing-helpers/mock-work-video.js
+++ b/src/testing-helpers/mock-work-video.js
@@ -1,0 +1,230 @@
+export const mockWorkVideo = {
+  accessionNumber: "avr:sq87bt762",
+  administrativeMetadata: {
+    libraryUnit: null,
+    preservationLevel: null,
+    projectCycle: null,
+    projectDesc: [],
+    projectManager: [],
+    projectName: [],
+    projectProposer: [],
+    projectTaskNumber: [],
+    status: null,
+  },
+  alternateTitle: [],
+  batches: [],
+  collection: {
+    id: "8cdf83c9-3831-4211-acd7-122bca9b89da",
+    title: "Northwestern University Football Films",
+  },
+  collectionTitle: "Northwestern University Football Films",
+  contributor: ["Agase, Alex, 1922-2007 (Contributor)"],
+  createDate: "2022-01-13T21:53:46.154150Z",
+  creator: ["Northwestern University (Evanston, Ill.)"],
+  dateCreated: ["September 4, 1971"],
+  description: ["Practice. Coach: Alex Agase."],
+  descriptiveMetadata: {
+    publisher: [],
+    provenance: [],
+    title: "Northwestern Football practice, 1971",
+    ark: "ark:/99999/fk4s76vd9f",
+    abstract: [],
+    culturalContext: [],
+    termsOfUse: null,
+    physicalDescriptionSize: [],
+    series: [],
+    relatedUrl: [],
+    identifier: [],
+    relatedMaterial: [],
+    source: [],
+    folderName: [],
+    genre: [
+      {
+        displayFacet: "Sports",
+        facet: "info:nul/e0f0ade3-1efd-4dcb-95c6-3b17d6b87be7||Sports|",
+        role: null,
+        term: {
+          id: "info:nul/e0f0ade3-1efd-4dcb-95c6-3b17d6b87be7",
+          label: "Sports",
+          variants: [],
+        },
+      },
+    ],
+    tableOfContents: [],
+    rightsStatement: null,
+    language: [],
+    subject: [
+      {
+        displayFacet:
+          "Northwestern University (Evanston, Ill.)--Football--History (Topical)",
+        facet:
+          "info:nul/a49b9347-b179-44a1-901f-d8176f74a8f3|TOPICAL|Northwestern University (Evanston, Ill.)--Football--History (Topical)",
+        role: {
+          id: "TOPICAL",
+          label: "Topical",
+          scheme: "subject_role",
+        },
+        term: {
+          id: "info:nul/a49b9347-b179-44a1-901f-d8176f74a8f3",
+          label: "Northwestern University (Evanston, Ill.)--Football--History",
+          variants: [],
+        },
+      },
+      {
+        displayFacet: "Northwestern Wildcats (Football team) (Topical)",
+        facet:
+          "info:nul/d2c4c732-888c-4d97-a3b9-ffaec9ebf2ac|TOPICAL|Northwestern Wildcats (Football team) (Topical)",
+        role: {
+          id: "TOPICAL",
+          label: "Topical",
+          scheme: "subject_role",
+        },
+        term: {
+          id: "info:nul/d2c4c732-888c-4d97-a3b9-ffaec9ebf2ac",
+          label: "Northwestern Wildcats (Football team)",
+          variants: [],
+        },
+      },
+      {
+        displayFacet: "Evanston, Illinois (Geographical)",
+        facet:
+          "info:nul/d8fc60c3-acc6-4eb6-a94c-44dd8950c4e8|GEOGRAPHICAL|Evanston, Illinois (Geographical)",
+        role: {
+          id: "GEOGRAPHICAL",
+          label: "Geographical",
+          scheme: "subject_role",
+        },
+        term: {
+          id: "info:nul/d8fc60c3-acc6-4eb6-a94c-44dd8950c4e8",
+          label: "Evanston, Illinois",
+          variants: [],
+        },
+      },
+    ],
+    location: [],
+    catalogKey: [],
+    folderNumber: [],
+    rightsHolder: [],
+    scopeAndContents: [],
+    technique: [],
+    boxNumber: [],
+    stylePeriod: [],
+    alternateTitle: [],
+    notes: [],
+    boxName: [],
+    keywords: [],
+    contributor: [
+      {
+        displayFacet: "Agase, Alex, 1922-2007 (Contributor)",
+        facet:
+          "http://id.loc.gov/authorities/names/n91079734|ctb|Agase, Alex, 1922-2007 (Contributor)",
+        role: {
+          id: "ctb",
+          label: "Contributor",
+          scheme: "marc_relator",
+        },
+        term: {
+          id: "http://id.loc.gov/authorities/names/n91079734",
+          label: "Agase, Alex, 1922-2007",
+          variants: ["Agase, Alexander, 1922-2007"],
+        },
+      },
+    ],
+    dateCreated: [
+      {
+        edtf: "1971-09-04",
+        humanized: "September 4, 1971",
+      },
+    ],
+    creator: [
+      {
+        displayFacet: "Northwestern University (Evanston, Ill.)",
+        facet:
+          "http://id.loc.gov/authorities/names/n79056815||Northwestern University (Evanston, Ill.)|",
+        role: null,
+        term: {
+          id: "http://id.loc.gov/authorities/names/n79056815",
+          label: "Northwestern University (Evanston, Ill.)",
+          variants: ["Northwestern Univerziteta (Evanston, Ill.)"],
+        },
+      },
+    ],
+    description: ["Practice. Coach: Alex Agase."],
+    citation: [],
+    license: null,
+    caption: [],
+    physicalDescriptionMaterial: [],
+    legacyIdentifier: ["sq87bt762"],
+  },
+  fileSets: [
+    {
+      accessionNumber: "avr:gh93gz86n",
+      description: null,
+      extractedMetadata: {},
+      id: "5e2c15ab-89d7-466c-a489-3a6eab9b45d0",
+      label: "Part 1",
+    },
+    {
+      accessionNumber: "avr:fb4948713",
+      description: null,
+      extractedMetadata: {},
+      id: "59157bd9-e75a-4ec0-99a2-dd7ede5a6e57",
+      label: "Part 3",
+    },
+    {
+      accessionNumber: "avr:br86b3944",
+      description: null,
+      extractedMetadata: {},
+      id: "33f74fe2-bf46-45cb-a4b5-6e1fe28cd8df",
+      label: "Part 4",
+    },
+    {
+      accessionNumber: "avr:sq87bt762:mods",
+      description: "MODS XML for AVR Work sq87bt762",
+      extractedMetadata: {},
+      id: "4950c8a0-d32e-4772-9fa7-33eedc2d36c9",
+      label: "h415p952n/sq87bt762.mods.xml",
+    },
+  ],
+  id: "777b7ffe-22a6-484e-aaed-c234e44188f4",
+  iiifManifest:
+    "https://iiif.stack.rdc-staging.library.northwestern.edu/public/iiif3/77/7b/7f/fe/-2/2a/6-/48/4e/-a/ae/d-/c2/34/e4/41/88/f4-manifest.json",
+  metadataUpdateJobs: [],
+  model: {
+    application: "Meadow",
+    name: "Work",
+  },
+  modifiedDate: "2022-01-15T15:02:26.337682Z",
+  project: {
+    id: "ecb5246f-9f12-473f-ad2a-7ced2861d569",
+    title: "AVR Migration",
+  },
+  published: false,
+  readingRoom: false,
+  representativeFileSet: {
+    fileSetId: "5e2c15ab-89d7-466c-a489-3a6eab9b45d0",
+    url: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/posters/5e2c15ab-89d7-466c-a489-3a6eab9b45d0",
+  },
+  sheet: {
+    id: "5dc6911a-6bfe-45d9-aec2-058243a0138a",
+    title: "avr_migration.csv",
+  },
+  subject: [
+    "Northwestern University (Evanston, Ill.)--Football--History",
+    "Northwestern Wildcats (Football team)",
+    "Evanston, Illinois",
+  ],
+  thumbnail:
+    "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/posters/5e2c15ab-89d7-466c-a489-3a6eab9b45d0/full/!300,300/0/default.jpg",
+  title: "Northwestern Football practice, 1971",
+  visibility: {
+    id: "OPEN",
+    label: "Public",
+    scheme: "visibility",
+  },
+  workType: {
+    id: "VIDEO",
+    label: "Video",
+    scheme: "work_type",
+  },
+};


### PR DESCRIPTION
## Summary 
This adds work type conditional statements for rendering the IIIF viewer containers on shared Items. I also added a new test and fixed some annoying warnings related to `  Warning: An update inside a test was not wrapped in act(...).`. Found this interesting solution and https://kentcdodds.com/blog/fix-the-not-wrapped-in-act-warning#an-alternative-waiting-for-the-mocked-promise and implemented it.

![image](https://user-images.githubusercontent.com/7376450/151622835-5d44e9c4-046b-4d34-88a7-0191bb912337.png)

## Steps to Test
1. Spin up DC with staging data
2. Go to meadow staging and find a Private Video or Audio work
3. Click Get Shareable Link
4. Append the `./shared/{id}` to your local devbox url ex: https://devbox.library.northwestern.edu:3333/shared/388c3961-c99d-4fbc-8ab7-e529a116078a
5. The work should render, and RMP should display
6. Mix and repeat steps 2-5 with an image work, OSD viewer should display 