### PR TITLE
Remove placeholder text [MEDIA] for work AV work types

### DIFF
--- a/src/components/UI/PhotoBox.tsx
+++ b/src/components/UI/PhotoBox.tsx
@@ -76,7 +76,6 @@ const PhotoBox: React.FC<PhotoBoxProps> = ({
         />
         <h4 data-testid="title-photo-box">
           <span css={lineHeight} className="button-link">
-            {["AUDIO", "VIDEO"].indexOf(workType) > -1 && "[MEDIA] "}
             {label}
           </span>
         </h4>


### PR DESCRIPTION
## Summary 
Remove placeholder text [MEDIA] for work AV work types

## Specific Changes in this PR
- Remove placeholder text [MEDIA] for work AV work types

## Steps to Test

- Check AV work types in search results. You shouldn't see "[MEDIA]" prepended to the title