### PR TITLE
Fix ThisItem default image display

### DIFF
--- a/src/components/Work/ThisItem.js
+++ b/src/components/Work/ThisItem.js
@@ -2,6 +2,12 @@ import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import PropTypes from "prop-types";
 import { IIIF_LARGE_FEATURE_REGION } from "../../services/global-vars";
+import imgPlaceholder from "images/book_placeholder.png";
+import avPlaceholder from "images/av_placeholder.png";
+
+const imagePlaceholder = (workType) => {
+  return workType === "IMAGE" ? imgPlaceholder : avPlaceholder;
+};
 
 const ThisItem = (props) => {
   const { item } = props;
@@ -31,7 +37,9 @@ const ThisItem = (props) => {
       <img
         src={
           item &&
-          `${item.representativeFileSet.url}${IIIF_LARGE_FEATURE_REGION}`
+          (item.representativeFileSet?.url
+            ? `${item.representativeFileSet.url}${IIIF_LARGE_FEATURE_REGION}`
+            : imagePlaceholder(item.workType.id))
         }
         alt={item && item.label}
       />


### PR DESCRIPTION
## Summary 

Fixes display of default images on the "ThisItem" section of a work page if the work does not have a `representativeFileSet`

## Specific Changes in this PR

- Fixes display of default images on the "ThisItem" section of a work page if the work does not have a `representativeFileSet`


## Steps to Test

Navigate to a work page where there is no representative file set and observe that a default image appropriate to the work type is displayed. 

<img width="1547" alt="Screen Shot 2022-02-03 at 2 09 07 PM" src="https://user-images.githubusercontent.com/6372022/152429804-8de67727-6cc8-46f1-9cc9-7138a69f737e.png">
