### PR TITLE
Change wording of notification on shared link page

### DIFF
--- a/src/components/SharedItem/Notification.js
+++ b/src/components/SharedItem/Notification.js
@@ -5,10 +5,25 @@ import moment from "moment";
 function SharedItemNotification({ expirationDate }) {
   return (
     <div className="shared-link-notification">
-      This work was shared with you via a temporary link. The link will expire:{" "}
-      <strong>
-        {moment(expirationDate).format("MMMM Do YYYY, h:mm:ss a")}
-      </strong>
+      <p>
+        Access to this resource is for educational, personal and non commercial
+        use. Written permission of copyright holders is required for
+        distribution.{" "}
+        <a
+          href="https://www.library.northwestern.edu/about/administration/policies/rights-permissions.html"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Read more
+        </a>
+      </p>
+      <p>
+        This work was shared with you via a temporary link. The link will
+        expire:{" "}
+        <strong>
+          {moment(expirationDate).format("MMMM Do YYYY, h:mm:ss a")}
+        </strong>
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary 

Updated text was provided for the notification area of a shared link page

## Specific Changes in this PR

- Text notification on shared link page modified

## Steps to Test

- Fire up dc with `npm run start:use-staging-data`
- Go to Meadow staging and create a shared link for a private work - Copy the link url and replace `https://dc.rdc-staging.library.northwestern.edu` with `https://devbox.library.northwestern.edu:3333` in the url
- Observe the updated text on the page


<img width="1728" alt="Screen Shot 2022-02-03 at 2 50 42 PM" src="https://user-images.githubusercontent.com/6372022/152435680-302c0fb5-deb7-485d-8410-e010d844acfc.png">
