### PR TITLE
Fix bug in Download tab for a media work

### DIFF
--- a/src/components/UI/IIIFImageEmbedModal.js
+++ b/src/components/UI/IIIFImageEmbedModal.js
@@ -83,7 +83,7 @@ export default function IIIFImageEmbedModal({
 
   useEffect(() => {
     function buildTag() {
-      return `<img src="${iiifServerUrl}/${id}/full/${width},/0/${color}.jpg" alt="${altLabel}">`;
+      return `<img src="${iiifServerUrl}/full/${width},/0/${color}.jpg" alt="${altLabel}" />`;
     }
     setEmbedCode(buildTag());
   }, [id, color, iiifServerUrl, width, altLabel]);

--- a/src/components/Work/Tabs/Download.js
+++ b/src/components/Work/Tabs/Download.js
@@ -26,13 +26,7 @@ const WorkTabsDownload = React.memo(function ({ item }) {
   const [modalOpen, setModalOpen] = useState();
   const [currentId, setCurrentId] = useState();
   const [currentLabel, setCurrentLabel] = useState();
-
-  console.log(item.representativeFileSet.url);
-
-  const iiifServerUrl = item.representativeFileSet.url.slice(
-    0,
-    item.representativeFileSet.url.lastIndexOf("/")
-  );
+  const [iiifServerUrl, setIIIFServerUrl] = useState("");
 
   useEffect(() => {
     fetch(item.iiifManifest)
@@ -59,10 +53,10 @@ const WorkTabsDownload = React.memo(function ({ item }) {
       .split("%2F")
       .join("");
 
-    console.log(row);
     setCurrentId(parsedId);
     setCurrentLabel(row.label);
     setModalOpen(true);
+    setIIIFServerUrl(row.id);
   }
 
   if (loading) return <UILoadingSpinner loading />;


### PR DESCRIPTION
## Summary 
Any works which didn't have a `representativeFileSet` property value were throwing an error in the "Download" tab.  We're now handling this scenario, and pulling the IIIF server url from a different source (off the manifest directly).

![image](https://user-images.githubusercontent.com/3020266/152604472-c2175cac-2e63-421e-abdf-eefac4071075.png)

![image](https://user-images.githubusercontent.com/3020266/152604563-e19df91c-c839-43cd-80ea-23a058c88314.png)

## Specific Changes in this PR
- Download tab will not throw errors for Media work types
- The HTML Embed works as well displaying a valid url.

## Steps to Test
Test the Download tab on the Work screen for media (audio / video) Work types which have some type aux images.  Also verify that Image Work types load properly as well.
