### PR TITLE
Constrain width of ThisItem placeholder image to 300px

### DIFF
--- a/src/components/Work/ThisItem.js
+++ b/src/components/Work/ThisItem.js
@@ -22,6 +22,10 @@ const ThisItem = (props) => {
       alignItems: "center",
       marginBottom: "5rem",
     },
+    thisItemImage: {
+      width: "300px",
+      height: "auto",
+    },
   };
 
   return (
@@ -42,6 +46,7 @@ const ThisItem = (props) => {
             : imagePlaceholder(item.workType.id))
         }
         alt={item && item.label}
+        style={styles.thisItemImage}
       />
     </div>
   );


### PR DESCRIPTION
## Summary 

Constrain width of ThisItem placeholder image to 300px

## Specific Changes in this PR

-Constrain width of ThisItem placeholder image to 300px

## Steps to Test

- Navigate to  a work page where the first ranked access file does not have a `representativeFileSet`. 
- Observe that the default placeholder image is 300px wide