### PR TITLE
Add key value to force rerender of clover on work change.

### DIFF
--- a/src/components/Work/MediaPlayer/Wrapper.tsx
+++ b/src/components/Work/MediaPlayer/Wrapper.tsx
@@ -16,7 +16,7 @@ const WorkMediaPlayerWrapper: React.FC<WorkMediaPlayerWrapperProps> = ({
   if (!manifestId) return null;
   return (
     <div data-testid="media-player-wrapper">
-      <CloverIIIF manifestId={manifestId} />
+      <CloverIIIF key={manifestId} manifestId={manifestId} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary 
Adds key value of the `manifestId` to `<CloverIIIF/>` component to force re-render on unique works. 

## Specific Changes in this PR
- Adds key value of the `manifestId` to `<CloverIIIF/>` 

## Steps to Test

### Note
Run `npm install` to make sure you have the most recent version of Clover IIIF (formerly RMP)


### Steps
Start up dc using `npm run start:use-real-data`

1. Go to https://devbox.library.northwestern.edu:3333/items/12c22c6e-129c-4e90-bcd2-eb6f21132dfd
2. Start playing any canvas
3. Scroll down and click on another work from the same collection Chicago Chamber Musicians Archive, 1989-2010
4. Clover will re-render along with the rest of the work