### PR TITLE
Update acquire license link into Google structured data

### DIFF
--- a/src/services/global-vars.js
+++ b/src/services/global-vars.js
@@ -80,6 +80,8 @@ export const productionUrl =
 
 // Google Tag Manager
 export const GOOGLE_TAG_MANAGER_ID = "GTM-MJ7RNV3";
+export const acquireLicensePage =
+  "https://www.library.northwestern.edu/about/administration/policies/rights-permissions.html";
 
 // React-router route config values
 export const ROUTES = {

--- a/src/services/google-structured-data.js
+++ b/src/services/google-structured-data.js
@@ -1,4 +1,4 @@
-import { productionUrl } from "./global-vars";
+import { acquireLicensePage, productionUrl } from "./global-vars";
 
 /**
  * Load default values for Google Structured Data
@@ -71,6 +71,7 @@ export function loadItemStructuredData(item, pathname) {
     thumbnail: itemImage,
     url: `${productionUrl}${pathname}`,
     ...(subject.length > 0 && { about: subject?.map((x) => x.term?.label) }),
+    acquireLicensePage,
     ...(creator.length > 0 && {
       author: item.descriptiveMetadata.creator.map((x) => x.term?.label),
     }),


### PR DESCRIPTION
## Summary 
Updates the `acquireLicensePage` field so it lands here:

<img width="1045" alt="image" src="https://user-images.githubusercontent.com/3020266/154978623-3b7b9146-e4fc-4f94-958a-5805bef68c88.png">


## Specific Changes in this PR
- Updates the `acquireLicensePage` field

## Steps to Test
Go to a Work, and open the browser dev console to see if the `acquireLicensePage` is in the output (as in screen shot above).
