### PR TITLE
Update spelling error on Shared Work notification

### DIFF
--- a/src/components/SharedItem/Notification.js
+++ b/src/components/SharedItem/Notification.js
@@ -6,7 +6,7 @@ function SharedItemNotification({ expirationDate }) {
   return (
     <div className="shared-link-notification">
       <p>
-        Access to this resource is for educational, personal and non commercial
+        Access to this resource is for educational, personal and noncommercial
         use. Written permission of copyright holders is required for
         distribution.{" "}
         <a


### PR DESCRIPTION
## Summary 
Spelling fix

## Specific Changes in this PR
- Spelling fix on Shared Work page

## Steps to Test
Share a work, and on the shared work page in DC, note that "non commercial" is now spelled "noncommercial".
 