### PR TITLE
Support previous and current Elasticsearch and OpenSearch implementations for response total values

### DIFF
--- a/src/api/elasticsearch-api.js
+++ b/src/api/elasticsearch-api.js
@@ -381,7 +381,9 @@ export async function getTotalItemCount() {
       },
     });
 
-    return response.hits.total;
+    return response.hits.total === "object"
+      ? response.hits.total.value
+      : response.hits.total;
   } catch (e) {
     return Promise.resolve(0);
   }

--- a/src/services/elasticsearch-parser.js
+++ b/src/services/elasticsearch-parser.js
@@ -39,7 +39,11 @@ function constructCarouselItems(docs, modelType) {
 export function extractCarouselData(elasticsearchResponse, modelType) {
   let obj = {};
 
-  obj.numFound = elasticsearchResponse.hits.total;
+  obj.numFound =
+    elasticsearchResponse.hits.total === "object"
+      ? elasticsearchResponse.hits.total.value
+      : elasticsearchResponse.hits.total;
+
   obj.items = constructCarouselItems(
     elasticsearchResponse.hits.hits,
     modelType


### PR DESCRIPTION
## Summary 
This PR adds support for the new shape of response data totals in Elasticsearch and OpenSearch. Previously the data returned was `response.hits.total`, but now `total` is an object so the retrieving the value requires `response.hits.total.value`.

## Specific Changes in this PR
- API and Parser code can retrieve total result counts from previous and current versions of Elasticsearch and OpenSerach.