### PR TITLE
Fix for Metadata links for Folder Number and Box Number

### DIFF
--- a/src/components/Work/MetadataDisplay.js
+++ b/src/components/Work/MetadataDisplay.js
@@ -35,23 +35,23 @@ const MetadataDisplay = ({
     const collectionTitle = getESTitle(collection, true);
 
     // Folder should filter on "collection", "box", and "folder" facets
-    if (facet.value === "Folder") {
+    if (facet.componentId === "FolderNumber") {
       encoded = encodeURI(
-        `Folder=["${adjustedSearchValue}"]&Box=["${
+        `FolderNumber=["${adjustedSearchValue}"]&Box=["${
           boxNumber[0]
         }"]&Collection=["${collectionTitle.split(" ").join("+")}"]`
       );
-
       return <Link to={`/search?${encoded}`}>{searchValue}</Link>;
     }
 
     // Box should only filter on "collection" and "box" facets
-    if (facet.value === "Box") {
+    if (facet.componentId === "BoxNumber") {
       encoded = encodeURI(
-        `Box=["${adjustedSearchValue}"]&Collection=["${collectionTitle
+        `BoxNumber=["${adjustedSearchValue}"]&Collection=["${collectionTitle
           .split(" ")
           .join("+")}"]`
       );
+      return <Link to={`/search?${encoded}`}>{searchValue}</Link>;
     }
 
     return (

--- a/src/components/Work/Tabs/Find.js
+++ b/src/components/Work/Tabs/Find.js
@@ -66,7 +66,7 @@ const TabsFind = ({ item }) => {
           items={findItem.value}
           facet={findItem.facet}
           externalUrl={findItem.externalUrl}
-          collection={item.collection[0]}
+          collection={item.collection}
           boxNumber={boxNumber}
         />
       ))}


### PR DESCRIPTION
## Summary 
Metadata links for Folder Number and Box Number now auto facet the appropriate facets

## Steps to Test
- Go to a Work
- Scroll down to "Find" tab, and click on a Box Number and Folder Number metadata link
- Notice the facets are correctly populated on the Search page.

Also please let developers know if there are any special instructions to test this in the development environment. 